### PR TITLE
Compatility w/ providers w/o targets

### DIFF
--- a/app-android/src/main/java/org/mtransit/android/datasource/DataSourcesReader.kt
+++ b/app-android/src/main/java/org/mtransit/android/datasource/DataSourcesReader.kt
@@ -282,9 +282,12 @@ class DataSourcesReader @Inject constructor(
                 if (providerMetaData.isKeyMT(statusProviderMetaData)) {
                     if (knownStatusProviderProperties.none { it.authority == providerAuthority }) {
                         providerMetaData.getString(statusProviderTargetMetaData)?.let { targetAuthority ->
-                            MTLog.d(this, "Status provider '${providerAuthority}' added.")
+                            val validTargetAuthority = targetAuthority.takeIf { it.isNotEmpty() }
+                                ?: pkgProviders.singleOrNull { it.metaData.isKeyMT(agencyProviderMetaData) }?.authority
+                                    .orEmpty() // will never be visible!
+                            MTLog.d(this, "Status provider '${providerAuthority}' added (target: '$validTargetAuthority').")
                             dataSourcesDatabase.statusProviderPropertiesDao().insert(
-                                StatusProviderProperties(providerAuthority, targetAuthority, pkg)
+                                StatusProviderProperties(providerAuthority, validTargetAuthority, pkg)
                             )
                             markUpdated()
                         }
@@ -294,9 +297,12 @@ class DataSourcesReader @Inject constructor(
                 if (providerMetaData.isKeyMT(scheduleProviderMetaData)) {
                     if (knownScheduleProviderProperties.none { it.authority == providerAuthority }) {
                         providerMetaData.getString(scheduleProviderTargetMetaData)?.let { targetAuthority ->
-                            MTLog.d(this, "Schedule provider '${providerAuthority}' added.")
+                            val validTargetAuthority = targetAuthority.takeIf { it.isNotEmpty() }
+                                ?: pkgProviders.singleOrNull { it.metaData.isKeyMT(agencyProviderMetaData) }?.authority
+                                    .orEmpty() // will never be visible!
+                            MTLog.d(this, "Schedule provider '${providerAuthority}' added (target: '$validTargetAuthority').")
                             dataSourcesDatabase.scheduleProviderPropertiesDao().insert(
-                                ScheduleProviderProperties(providerAuthority, targetAuthority, pkg)
+                                ScheduleProviderProperties(providerAuthority, validTargetAuthority, pkg)
                             )
                             markUpdated()
                         }
@@ -306,9 +312,12 @@ class DataSourcesReader @Inject constructor(
                 if (providerMetaData.isKeyMT(serviceUpdateProviderMetaData)) {
                     if (knownServiceUpdateProviderProperties.none { it.authority == providerAuthority }) {
                         providerMetaData.getString(serviceUpdateProviderTargetMetaData)?.let { targetAuthority ->
-                            MTLog.d(this, "Service Update provider '${providerAuthority}' added.")
+                            val validTargetAuthority = targetAuthority.takeIf { it.isNotEmpty() }
+                                ?: pkgProviders.singleOrNull { it.metaData.isKeyMT(agencyProviderMetaData) }?.authority
+                                    .orEmpty() // will never be visible!
+                            MTLog.d(this, "Service Update provider '${providerAuthority}' added (target: '$validTargetAuthority').")
                             dataSourcesDatabase.serviceUpdateProviderPropertiesDao().insert(
-                                ServiceUpdateProviderProperties(providerAuthority, targetAuthority, pkg)
+                                ServiceUpdateProviderProperties(providerAuthority, validTargetAuthority, pkg)
                             )
                             markUpdated()
                         }
@@ -318,9 +327,11 @@ class DataSourcesReader @Inject constructor(
                 if (providerMetaData.isKeyMT(newsProviderMetaData)) {
                     if (knownNewsProviderProperties.none { it.authority == providerAuthority }) {
                         providerMetaData.getString(newsProviderTargetMetaData)?.let { targetAuthority ->
-                            MTLog.d(this, "News provider '${providerAuthority}' added.")
+                            val validTargetAuthority = targetAuthority.takeIf { it.isNotEmpty() }
+                                ?: pkgProviders.singleOrNull { it.metaData.isKeyMT(agencyProviderMetaData) }?.authority
+                                    .orEmpty() // will only be visible in News screen
                             dataSourcesDatabase.newsProviderPropertiesDao().insert(
-                                NewsProviderProperties(providerAuthority, targetAuthority, pkg)
+                                NewsProviderProperties(providerAuthority, validTargetAuthority, pkg)
                             )
                             markUpdated()
                         }


### PR DESCRIPTION
Default target should be agency authority (99% use cases)

(will need to keep putting target in XML files until next Prod release adopted 90%)