### PR TITLE
Web browser screen > allow untrusted SSL error (only for stm.info)

### DIFF
--- a/app-android/src/main/java/org/mtransit/android/ui/fragment/WebBrowserFragment.java
+++ b/app-android/src/main/java/org/mtransit/android/ui/fragment/WebBrowserFragment.java
@@ -537,8 +537,10 @@ public class WebBrowserFragment extends ABFragment implements MenuProvider {
 			case SslError.SSL_UNTRUSTED:
 				if (urlHost != null && urlHost.endsWith("stm.info")) {
 					handler.proceed();
-					break;
+				} else {
+					handler.cancel();
 				}
+				break;
 			case SslError.SSL_NOTYETVALID:
 			case SslError.SSL_DATE_INVALID:
 			case SslError.SSL_EXPIRED:
@@ -547,7 +549,7 @@ public class WebBrowserFragment extends ABFragment implements MenuProvider {
 				handler.cancel();
 				break;
 			default:
-				MTLog.w(this, "Unknown SSL Error (%d) on certificate: '%s'!", error.getPrimaryError(), error.getCertificate());
+				MTLog.w(this, "Unknown SSL Error (%d) on '%s' certificate: '%s'!", error.getPrimaryError(), urlHost, error.getCertificate());
 				handler.cancel();
 				break;
 			}

--- a/app-android/src/main/java/org/mtransit/android/ui/fragment/WebBrowserFragment.java
+++ b/app-android/src/main/java/org/mtransit/android/ui/fragment/WebBrowserFragment.java
@@ -526,7 +526,7 @@ public class WebBrowserFragment extends ABFragment implements MenuProvider {
 
 		@SuppressLint("WebViewClientOnReceivedSslError")
 		@Override
-		public void onReceivedSslError(WebView webView, SslErrorHandler handler, SslError sslError) {
+		public void onReceivedSslError(WebView webView, SslErrorHandler sslErrorHandler, SslError sslError) {
 			final String url = webView.getUrl();
 			final int primaryError = sslError.getPrimaryError();
 			final SslCertificate certificate = sslError.getCertificate();
@@ -540,9 +540,9 @@ public class WebBrowserFragment extends ABFragment implements MenuProvider {
 			switch (primaryError) {
 			case SslError.SSL_UNTRUSTED:
 				if (urlHost != null && urlHost.endsWith("stm.info")) {
-					handler.proceed();
+					sslErrorHandler.proceed();
 				} else {
-					handler.cancel();
+					sslErrorHandler.cancel();
 				}
 				break;
 			case SslError.SSL_NOTYETVALID:
@@ -550,11 +550,11 @@ public class WebBrowserFragment extends ABFragment implements MenuProvider {
 			case SslError.SSL_EXPIRED:
 			case SslError.SSL_IDMISMATCH:
 			case SslError.SSL_INVALID:
-				handler.cancel();
+				sslErrorHandler.cancel();
 				break;
 			default:
 				MTLog.w(this, "Unknown SSL Error (%d) on '%s' certificate: '%s'!", primaryError, urlHost, certificate);
-				handler.cancel();
+				sslErrorHandler.cancel();
 				break;
 			}
 		}


### PR DESCRIPTION
> **Unsafe Implementation of WebView SSL Error Handler**
> We found that your app contains security vulnerabilities, which can expose user information or damage a user’s device. This is a violation of Device and Network Abuse policy. Specifically, your app(s) contain an unsafe implementation of WebView SSL Error Handler.
> To address this issue, follow the steps in this [Google Help Center](https://support.google.com/faqs/answer/7071387) article.