### PR TITLE
POI status management fix

### DIFF
--- a/app-android/src/main/java/org/mtransit/android/data/POIManager.java
+++ b/app-android/src/main/java/org/mtransit/android/data/POIManager.java
@@ -213,10 +213,10 @@ public class POIManager implements LocationPOI,
 			return false; // no change
 		}
 		if (this.status != null && this.status.isUseful()) {
-			if (this.status != null && this.status.getReadFromSourceAtInMs() > newStatus.getReadFromSourceAtInMs()) {
+			if (this.status.getReadFromSourceAtInMs() > newStatus.getReadFromSourceAtInMs()) {
 				return false; // no change
 			}
-			if (this.status != null && !this.status.isNoData() && newStatus.isNoData()) {
+			if (!this.status.isNoData() && newStatus.isNoData()) {
 				return false; // keep status w/ data
 			}
 		}


### PR DESCRIPTION
Avoid keeping outdated real-time status when static schedule available.

This creates bug when only real-time schedule status is close to 0 minutes and shows "no service" status text because it ignore static data (read from source older)