### PR TITLE
Source label > fix read time in the near future

### DIFF
--- a/app-android/src/main/java/org/mtransit/android/ui/common/UISourceLabelUtils.kt
+++ b/app-android/src/main/java/org/mtransit/android/ui/common/UISourceLabelUtils.kt
@@ -5,6 +5,7 @@ import android.widget.TextView
 import androidx.core.util.PatternsCompat
 import org.mtransit.android.R
 import org.mtransit.android.commons.MTLog
+import org.mtransit.android.commons.TimeUtils
 import org.mtransit.android.commons.data.POIStatus
 import org.mtransit.android.commons.data.ServiceUpdate
 import org.mtransit.android.commons.data.distinctByOriginalId
@@ -59,11 +60,12 @@ object UISourceLabelUtils : MTLog.Loggable {
         ?.distinct()
         ?.let { sourceLabels ->
             readFromSource?.let {
+                val now = TimeUtils.currentTimeMillis()
                 context.resources.getQuantityString(
                     R.plurals.source_label_and_sources_and_time,
                     sourceLabels.size,
                     sourceLabels.joinToString(),
-                    UITimeUtils.formatRelativeTime(it.toMillis())
+                    UITimeUtils.formatRelativeTime(it.toMillis().coerceAtMost(now), now)
                 )
             } ?: run {
                 context.resources.getQuantityString(

--- a/app-android/src/main/java/org/mtransit/android/util/UITimeUtils.java
+++ b/app-android/src/main/java/org/mtransit/android/util/UITimeUtils.java
@@ -184,7 +184,7 @@ public class UITimeUtils extends org.mtransit.android.commons.TimeUtils implemen
 	}
 
 	@NonNull
-	private static CharSequence formatRelativeTime(long timeInThePastInMs, long nowInMs) {
+	public static CharSequence formatRelativeTime(long timeInThePastInMs, long nowInMs) {
 		return DateUtils.getRelativeTimeSpanString(timeInThePastInMs, nowInMs, DateUtils.MINUTE_IN_MILLIS, DateUtils.FORMAT_ABBREV_RELATIVE);
 	}
 


### PR DESCRIPTION
Update time formatting to use current time for relative display.

Read from source comes from backend servers with milliseconds precision so it can be slightly in the future and display `In 0 mins` instead of `0 mins ago`