### PR TITLE
Analytics: revert `RDSRouteFragment` -> `RTSRouteFragment` screen view class

### DIFF
--- a/app-android/src/main/java/org/mtransit/android/ui/rds/route/RDSRouteFragment.kt
+++ b/app-android/src/main/java/org/mtransit/android/ui/rds/route/RDSRouteFragment.kt
@@ -1,4 +1,4 @@
-@file:JvmName("RTSRouteFragment") // ANALYTICS // do not change to avoid breaking tracking
+@file:JvmName("RDSRouteFragment") // ANALYTICS // do not change to avoid breaking tracking
 package org.mtransit.android.ui.rds.route
 
 import android.app.PendingIntent


### PR DESCRIPTION
Fix regression created in:
- #50 ([file](https://github.com/mtransitapps/mtransit-for-android/pull/50/files#diff-33ac9b20ca5b35f2f486611db5a84f9af851090393afeec3e7827d8d7ea2b3df))

In Production since:
- https://github.com/mtransitapps/mtransit-for-android/releases/tag/25.08.31_r4401

Links:
- [Rename and generate new events - Analytics Help](https://support.google.com/analytics/answer/10085872)
- [Edit events in Google Analytics properties - YouTube](https://www.youtube.com/watch?v=uX2rBgFfAJo)