### PR TITLE
Fix crash in `POIArrayAdapter`

### DIFF
--- a/app-android/src/main/java/org/mtransit/android/data/POIArrayAdapterExt.kt
+++ b/app-android/src/main/java/org/mtransit/android/data/POIArrayAdapterExt.kt
@@ -34,7 +34,7 @@ fun POIArrayAdapter.onCreateViewKt(viewLifecycleOwner: LifecycleOwner) {
             if (hasFavorites && hasAgenciesEnabled) {
                 add(0, DataSourceType.TYPE_FAVORITE) // 1st
             }
-            if (allNewsProviders.isNotEmpty()) {
+            if (isNotEmpty() && allNewsProviders.isNotEmpty()) {
                 add(this.size - 1, DataSourceType.TYPE_NEWS) // before LAST (MODULE)
             }
         }


### PR DESCRIPTION
Created in:
- #219

```
Exception java.lang.IndexOutOfBoundsException: index: -1, size: 0
  at kotlin.collections.AbstractList$Companion.checkPositionIndex$kotlin_stdlib (AbstractList.kt:124)
  at kotlin.collections.builders.ListBuilder.add (ListBuilder.kt:87)
  at org.mtransit.android.data.POIArrayAdapterExtKt.onCreateViewKt$lambda$1 (POIArrayAdapterExt.kt:38)
  at androidx.lifecycle.Transformations.map$lambda$0 (Transformations.java:58)
  at androidx.lifecycle.Transformations$sam$androidx_lifecycle_Observer$0.onChanged (Transformations.kt:14)
  at androidx.lifecycle.MediatorLiveData$Source.onChanged (MediatorLiveData.java:172)
  at androidx.lifecycle.LiveData.considerNotify (LiveData.java:134)
  at androidx.lifecycle.LiveData.dispatchingValue (LiveData.java:152)
  at androidx.lifecycle.LiveData.setValue (LiveData.java:310)
  at org.mtransit.android.ui.view.common.MediatorLiveData4._init_$lambda$3 (MediatorLiveData4.java:41)
  at org.mtransit.android.ui.view.common.MediatorLiveData4$sam$androidx_lifecycle_Observer$0.onChanged (MediatorLiveData4.java:8)
  at androidx.lifecycle.MediatorLiveData$Source.onChanged (MediatorLiveData.java:172)
  at androidx.lifecycle.LiveData.considerNotify (LiveData.java:134)
  at androidx.lifecycle.LiveData.dispatchingValue (LiveData.java:152)
  at androidx.lifecycle.LiveData.setValue (LiveData.java:310)
  at androidx.lifecycle.Transformations.distinctUntilChanged$lambda$0 (Transformations.java:210)
  at androidx.lifecycle.Transformations$sam$androidx_lifecycle_Observer$0.onChanged (Transformations.kt:14)
  at androidx.lifecycle.MediatorLiveData$Source.onChanged (MediatorLiveData.java:172)
  at androidx.lifecycle.LiveData.considerNotify (LiveData.java:134)
  at androidx.lifecycle.LiveData.dispatchingValue (LiveData.java:152)
  at androidx.lifecycle.LiveData.setValue (LiveData.java:310)
  at androidx.lifecycle.CoroutineLiveDataKt$addDisposableSource$2.invokeSuspend$lambda$0 (CoroutineLiveData.kt:109)
  at androidx.lifecycle.CoroutineLiveDataKt$sam$androidx_lifecycle_Observer$0.onChanged (CoroutineLiveData.kt:10)
  at androidx.lifecycle.MediatorLiveData$Source.onChanged (MediatorLiveData.java:172)
  at androidx.lifecycle.LiveData.considerNotify (LiveData.java:134)
  at androidx.lifecycle.LiveData.dispatchingValue (LiveData.java:152)
  at androidx.lifecycle.LiveData.setValue (LiveData.java:310)
  at androidx.lifecycle.Transformations.map$lambda$0 (Transformations.java:58)
  at androidx.lifecycle.Transformations$sam$androidx_lifecycle_Observer$0.onChanged (Transformations.kt:14)
  at androidx.lifecycle.MediatorLiveData$Source.onChanged (MediatorLiveData.java:172)
  at androidx.lifecycle.LiveData.considerNotify (LiveData.java:134)
  at androidx.lifecycle.LiveData.dispatchingValue (LiveData.java:152)
  at androidx.lifecycle.LiveData.setValue (LiveData.java:310)
  at androidx.lifecycle.LiveData$1.run (LiveData.java:94)
  at android.os.Handler.handleCallback (Handler.java:958)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:230)
  at android.os.Looper.loop (Looper.java:319)
  at android.app.ActivityThread.main (ActivityThread.java:8893)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:608)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1103)
```

Found by [Play Console Pre-launch report](https://play.google.com/console/about/pre-launchreports/) 🚀 