### PR TITLE
Refresh setup required > yield if cancelled in Splash Screen

### DIFF
--- a/app-android/src/main/java/org/mtransit/android/datasource/DataSourcesReader.kt
+++ b/app-android/src/main/java/org/mtransit/android/datasource/DataSourcesReader.kt
@@ -8,6 +8,7 @@ import androidx.core.content.edit
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 import org.mtransit.android.analytics.AnalyticsUserProperties
 import org.mtransit.android.analytics.IAnalyticsManager
 import org.mtransit.android.common.repository.LocalPreferenceRepository
@@ -32,7 +33,6 @@ import org.mtransit.android.data.ScheduleProviderProperties
 import org.mtransit.android.data.ServiceUpdateProviderProperties
 import org.mtransit.android.data.StatusProviderProperties
 import org.mtransit.android.data.VehicleLocationProviderProperties
-import org.mtransit.android.toDateTimeLog
 import org.mtransit.android.toDurationLog
 import org.mtransit.android.util.UIFeatureFlags
 import java.util.concurrent.TimeUnit

--- a/app-android/src/main/java/org/mtransit/android/datasource/DataSourcesReader.kt
+++ b/app-android/src/main/java/org/mtransit/android/datasource/DataSourcesReader.kt
@@ -260,7 +260,7 @@ class DataSourcesReader @Inject constructor(
         dataSourcesDatabase.agencyPropertiesDao().getAllEnabledAgencies()
             .filter { forcePkg == null || forcePkg == it.pkg }
             .forEach { agencyProperties ->
-                yield() // stop if canceled #SpashScreen
+                yield() // stop if canceled #SplashScreen
                 val pkg = agencyProperties.pkg
                 val authority = agencyProperties.authority
                 if (skipNotSupportedPkg(pkg)) {

--- a/app-android/src/main/java/org/mtransit/android/datasource/DataSourcesReader.kt
+++ b/app-android/src/main/java/org/mtransit/android/datasource/DataSourcesReader.kt
@@ -260,6 +260,7 @@ class DataSourcesReader @Inject constructor(
         dataSourcesDatabase.agencyPropertiesDao().getAllEnabledAgencies()
             .filter { forcePkg == null || forcePkg == it.pkg }
             .forEach { agencyProperties ->
+                yield() // stop if canceled #SpashScreen
                 val pkg = agencyProperties.pkg
                 val authority = agencyProperties.authority
                 if (skipNotSupportedPkg(pkg)) {


### PR DESCRIPTION
Added `yield()` to stop processing if canceled in `DataSourcesReader`.

Only an issue on slow device and/or lot of transit agencies modules installed.