### PR TITLE
Fix crash in purchase dialog when trying to use lifecycle

### DIFF
--- a/app-android/src/main/java/org/mtransit/android/ui/fragment/PurchaseDialogFragmentExt.kt
+++ b/app-android/src/main/java/org/mtransit/android/ui/fragment/PurchaseDialogFragmentExt.kt
@@ -1,12 +1,15 @@
 package org.mtransit.android.ui.fragment
 
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.mtransit.android.ad.IAdManager
 
 fun PurchaseDialogFragment.onResumeKt(iAdManager: IAdManager) {
-    this.lifecycleScope.launch(Dispatchers.IO) {
+    @Suppress("DEPRECATION") // FIXME migrate fragment to AndroidX
+    val parentActivity = this.activity as? FragmentActivity ?: return
+    parentActivity.lifecycleScope.launch(Dispatchers.IO) {
         iAdManager.refreshRewardedAdStatus(this@onResumeKt)
     }
 }

--- a/app-android/src/main/java/org/mtransit/android/ui/fragment/PurchaseDialogFragmentExt.kt
+++ b/app-android/src/main/java/org/mtransit/android/ui/fragment/PurchaseDialogFragmentExt.kt
@@ -1,15 +1,17 @@
 package org.mtransit.android.ui.fragment
 
+import android.annotation.SuppressLint
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.lifecycleScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.mtransit.android.ad.IAdManager
 
+@SuppressLint("DeprecatedCall") // FIXME migrate fragment to AndroidX
+@Suppress("DEPRECATION") // FIXME migrate fragment to AndroidX
 fun PurchaseDialogFragment.onResumeKt(iAdManager: IAdManager) {
-    @Suppress("DEPRECATION") // FIXME migrate fragment to AndroidX
     val parentActivity = this.activity as? FragmentActivity ?: return
-    parentActivity.lifecycleScope.launch(Dispatchers.IO) {
+    parentActivity.lifecycleScope.launch {
+        if (!isAdded) return@launch
         iAdManager.refreshRewardedAdStatus(this@onResumeKt)
     }
 }


### PR DESCRIPTION
Created in https://github.com/mtransitapps/mtransit-for-android/pull/219

```
Caused by java.lang.IllegalStateException: Fragment PurchaseDialogFragment{8bdccce https://github.com/mtransitapps/mtransit-for-android/issues/1 dialog} is NOT compatible with Lifecycle!
       at org.mtransit.android.ui.fragment.PurchaseDialogFragment.getLifecycle(PurchaseDialogFragment.java:180)
       at androidx.lifecycle.LifecycleOwnerKt.getLifecycleScope(LifecycleOwner.kt:48)
       at org.mtransit.android.ui.fragment.PurchaseDialogFragmentExtKt.onResumeKt(PurchaseDialogFragmentExt.kt:9)
       at org.mtransit.android.ui.fragment.PurchaseDialogFragment.onResume(PurchaseDialogFragment.java:332)
```