### PR TITLE
POI > schedule status > fix "no data" shown as "no service" before valid status

### DIFF
--- a/app-android/src/main/java/org/mtransit/android/data/POIManager.java
+++ b/app-android/src/main/java/org/mtransit/android/data/POIManager.java
@@ -201,15 +201,20 @@ public class POIManager implements LocationPOI,
 			return false; // no change
 		}
 		// 2 - validate new status more useful & better than current status
-		if (this.status != null && this.status.isUseful()) {
-			if (this.status.getReadFromSourceAtInMs() > newStatus.getReadFromSourceAtInMs()) {
-				return false; // keep status with more recent source
+		if (this.status != null) {
+			if (this.status.isUseful()) {
+				if (this.status.getReadFromSourceAtInMs() > newStatus.getReadFromSourceAtInMs()) {
+					MTLog.d(this, "setStatus() > IGNORE (new status older than current status)");
+					return false; // keep status with more recent source
+				}
 			}
-			if (this.status.hasData() && !newStatus.hasData()) {
-				return false; // keep status w/ data
+			if (!this.status.isNoData() && newStatus.isNoData()) {
+				MTLog.d(this, "setStatus() > IGNORE (new status is 'no data')");
+				return false; // keep status w/o 'no data'
 			}
 		}
 		// 3 - use status
+		MTLog.d(this, "setStatus() > USE new status");
 		this.status = newStatus;
 		return true; // change
 	}

--- a/app-android/src/main/java/org/mtransit/android/data/POIManager.java
+++ b/app-android/src/main/java/org/mtransit/android/data/POIManager.java
@@ -203,7 +203,7 @@ public class POIManager implements LocationPOI,
 		// 2 - validate new status more useful & better than current status
 		if (this.status != null && this.status.isUseful()) {
 			if (this.status.getReadFromSourceAtInMs() > newStatus.getReadFromSourceAtInMs()) {
-				return false; // no change
+				return false; // keep status with more recent source
 			}
 			if (this.status.hasData() && !newStatus.hasData()) {
 				return false; // keep status w/ data

--- a/app-android/src/main/java/org/mtransit/android/data/UISchedule.java
+++ b/app-android/src/main/java/org/mtransit/android/data/UISchedule.java
@@ -1003,7 +1003,7 @@ public class UISchedule extends org.mtransit.android.commons.data.Schedule imple
 			@Nullable ServiceUpdates serviceUpdates
 	) {
 		if (!hasData()) { // NO DATA
-			generateStatusStringsNoService(context);
+			this.statusStrings = new ArrayList<>(); // nothing to show
 			this.statusStringsTimestamp = after;
 			return;
 		}

--- a/app-android/src/main/java/org/mtransit/android/data/UISchedule.java
+++ b/app-android/src/main/java/org/mtransit/android/data/UISchedule.java
@@ -1014,7 +1014,7 @@ public class UISchedule extends org.mtransit.android.commons.data.Schedule imple
 			@Nullable ServiceUpdates serviceUpdates
 	) {
 		if (isNoData()) { // NO DATA
-			this.statusStrings = new ArrayList<>(); // nothing to show
+			this.statusStrings = new ArrayList<>(); // 'no data' status is never displayed
 			this.statusStringsTimestamp = after;
 			return;
 		}

--- a/app-android/src/main/java/org/mtransit/android/data/UISchedule.java
+++ b/app-android/src/main/java/org/mtransit/android/data/UISchedule.java
@@ -331,21 +331,6 @@ public class UISchedule extends org.mtransit.android.commons.data.Schedule imple
 		realTimeImage = null;
 	}
 
-	@Nullable
-	private ArrayList<DetailsNextDepartures> scheduleList = null;
-
-	private long scheduleListTimestamp = -1L;
-
-	@Nullable
-	private CharSequence scheduleString = null;
-
-	private long scheduleStringTimestamp = -1L;
-
-	@Nullable
-	private Pair<CharSequence, CharSequence> statusStrings = null;
-
-	private long statusStringsTimestamp = -1L;
-
 	protected UISchedule(@NonNull org.mtransit.android.commons.data.Schedule schedule) {
 		this(
 				schedule,
@@ -475,6 +460,11 @@ public class UISchedule extends org.mtransit.android.commons.data.Schedule imple
 	}
 
 	// SCHEDULE LIST
+
+	@Nullable
+	private ArrayList<DetailsNextDepartures> scheduleList = null;
+
+	private long scheduleListTimestamp = -1L;
 
 	@Nullable
 	public ArrayList<DetailsNextDepartures> getScheduleList(
@@ -848,6 +838,15 @@ public class UISchedule extends org.mtransit.android.commons.data.Schedule imple
 	// SCHEDULE
 
 	@Deprecated // TBD
+	@SuppressLint("DeprecatedCall")
+	@Nullable
+	private CharSequence scheduleString = null;
+
+	@Deprecated // TBD
+	@SuppressLint("DeprecatedCall")
+	private long scheduleStringTimestamp = -1L;
+
+	@Deprecated // TBD
 	@SuppressWarnings({"unused", "deprecation"})
 	@SuppressLint("DeprecatedCall")
 	@Nullable
@@ -990,6 +989,11 @@ public class UISchedule extends org.mtransit.android.commons.data.Schedule imple
 	// STATUS
 
 	@Nullable
+	private Pair<CharSequence, CharSequence> statusStrings = null;
+
+	private long statusStringsTimestamp = -1L;
+
+	@Nullable
 	public Pair<CharSequence, CharSequence> getStatus(
 			@NonNull Context context,
 			long after,
@@ -1015,35 +1019,26 @@ public class UISchedule extends org.mtransit.android.commons.data.Schedule imple
 			@Nullable ServiceUpdates serviceUpdates
 	) {
 		if (isNoData()) { // NO DATA
-			this.statusStrings = new Pair<>(null, null); // 'no data' status is never displayed
-			this.statusStringsTimestamp = after;
+			setStatusStrings(getStatusStringNoData(), after);
 			return;
 		}
-		if (isNoPickup()) { // NO PICKUP
-			if (this.statusStrings == null) {
-				generateStatusStringsNoPickup(context);
-			} // ELSE descent only already set
-			this.statusStringsTimestamp = after;
+		if (isNoPickup()) { // NO PICKUP schedule
+			setStatusStrings(getStatusStringsNoPickup(context), after);
 			return;
 		}
 		final Frequency frequency = getCurrentFrequency(after);
 		if (frequency != null && frequency.headwayInSec < MAX_FREQUENCY_DISPLAYED_IN_SEC) { // FREQUENCY
-			generateStatusStringsFrequency(context, frequency);
-			this.statusStringsTimestamp = after;
+			setStatusStrings(getStatusStringsFrequency(context, frequency), after);
 			return;
 		}
 		ArrayList<Timestamp> nextTimestamps = getStatusNextTimestamps(after, optMinCoverageInMs, optMaxCoverageInMs, optMinCount, optMaxCount);
 		if (nextTimestamps.isEmpty()) { // NO SERVICE IN COVERAGE
-			generateStatusStringsNoService(context);
-			this.statusStringsTimestamp = after;
+			setStatusStrings(getStatusStringsNoService(context), after);
 			return;
 		}
 		CollectionUtils.removeIfNN(nextTimestamps, Timestamp::isNoPickup);
-		if (nextTimestamps.isEmpty()) { // NO PICKUP SERVICE
-			if (this.statusStrings == null) {
-				generateStatusStringsNoPickup(context);
-			} // ELSE descent only already set
-			this.statusStringsTimestamp = after;
+		if (nextTimestamps.isEmpty()) { // NO PICKUP schedule timestamps
+			setStatusStrings(getStatusStringsNoPickup(context), after);
 			return;
 		}
 		final long diffInMs = nextTimestamps.get(0).getDepartureT() - after;
@@ -1053,12 +1048,15 @@ public class UISchedule extends org.mtransit.android.commons.data.Schedule imple
 						&& diffInMs < UITimeUtils.FREQUENT_SERVICE_TIME_SPAN_IN_MS_DEFAULT //
 						&& UITimeUtils.isFrequentService(nextTimestamps, -1, -1); // needs more than 3 services times!
 		if (isFrequentService) { // FREQUENT SERVICE
-			generateStatusStringsFrequentService(context);
-			this.statusStringsTimestamp = after;
+			setStatusStrings(getStatusStringsFrequentService(context), after);
 			return;
 		}
 		nextTimestamps = filterStatusNextTimestampsTimes(nextTimestamps);
-		generateStatusStringsTimes(context, after, diffInMs, nextTimestamps, serviceUpdates);
+		setStatusStrings(getStatusStringsTimes(context, after, diffInMs, nextTimestamps, serviceUpdates), after);
+	}
+
+	private void setStatusStrings(@Nullable Pair<CharSequence, CharSequence> statusStrings, long after) {
+		this.statusStrings = statusStrings;
 		this.statusStringsTimestamp = after;
 	}
 
@@ -1132,7 +1130,7 @@ public class UISchedule extends org.mtransit.android.commons.data.Schedule imple
 		return nextTimestampsT;
 	}
 
-	private void generateStatusStringsTimes(
+	private Pair<CharSequence, CharSequence> getStatusStringsTimes(
 			@NonNull Context context,
 			long recentEnoughToBeNow,
 			long diffInMs,
@@ -1192,7 +1190,7 @@ public class UISchedule extends org.mtransit.android.commons.data.Schedule imple
 			line1CS = decorateCancelled(nextTimestamp, line1CS, serviceUpdates);
 			if (line2CS != null) line2CS = decorateCancelled(nextTimestamp, line2CS, serviceUpdates);
 		}
-		this.statusStrings = new Pair<>(line1CS, line2CS);
+		return new Pair<>(line1CS, line2CS);
 	}
 
 	@Nullable
@@ -1225,7 +1223,11 @@ public class UISchedule extends org.mtransit.android.commons.data.Schedule imple
 				getStatusSpaceTextAppearance(context), STATUS_FONT);
 	}
 
-	private void generateStatusStringsFrequency(@NonNull Context context, @NonNull Frequency frequency) {
+	private Pair<CharSequence, CharSequence> getStatusStringNoData() {
+		return new Pair<>(null, null);
+	}
+
+	private Pair<CharSequence, CharSequence> getStatusStringsFrequency(@NonNull Context context, @NonNull Frequency frequency) {
 		int headwayInMin = frequency.headwayInSec / 60;
 		CharSequence headway = UITimeUtils.getNumberInLetter(context, headwayInMin);
 		final SpannableStringBuilder cs1 = new SpannableStringBuilder(context.getResources().getQuantityString(R.plurals.every_minutes_and_quantity_part_1, headwayInMin, headway));
@@ -1234,27 +1236,23 @@ public class UISchedule extends org.mtransit.android.commons.data.Schedule imple
 			SpanUtils.setAll(cs1, SCHEDULE_OLD_SCHEDULE_STYLE);
 			SpanUtils.setAll(cs2, SCHEDULE_OLD_SCHEDULE_STYLE);
 		}
-		generateStatusStrings(context, cs1, cs2);
+		return getStatusStringsAndFormatting(context, cs1, cs2);
 	}
 
-	private void generateStatusStringsNoService(@NonNull Context context) {
-		generateStatusStrings(context, context.getString(R.string.no_service_part_1), context.getString(R.string.no_service_part_2));
+	private Pair<CharSequence, CharSequence> getStatusStringsNoService(@NonNull Context context) {
+		return getStatusStringsAndFormatting(context, context.getString(R.string.no_service_part_1), context.getString(R.string.no_service_part_2));
 	}
 
-	private void generateStatusStringsFrequentService(@NonNull Context context) {
-		generateStatusStrings(context, context.getString(R.string.frequent_service_part_1), context.getString(R.string.frequent_service_part_2));
+	private Pair<CharSequence, CharSequence> getStatusStringsFrequentService(@NonNull Context context) {
+		return getStatusStringsAndFormatting(context, context.getString(R.string.frequent_service_part_1), context.getString(R.string.frequent_service_part_2));
 	}
 
-	private void generateStatusStringsNoPickup(@NonNull Context context) {
-		generateStatusStrings(context, context.getString(R.string.drop_off_only_part_1), context.getString(R.string.drop_off_only_part_2));
+	private Pair<CharSequence, CharSequence> getStatusStringsNoPickup(@NonNull Context context) {
+		return getStatusStringsAndFormatting(context, context.getString(R.string.drop_off_only_part_1), context.getString(R.string.drop_off_only_part_2));
 	}
 
-	private void generateStatusStrings(
-			@NonNull Context context,
-			CharSequence cs1,
-			CharSequence cs2
-	) {
-		this.statusStrings = new Pair<>(
+	private Pair<CharSequence, CharSequence> getStatusStringsAndFormatting(@NonNull Context context, CharSequence cs1, CharSequence cs2) {
+		return new Pair<>(
 				SpanUtils.setAll(cs1,
 						getStatusStringTextAppearance(context),
 						STATUS_FONT,

--- a/app-android/src/main/java/org/mtransit/android/data/UISchedule.java
+++ b/app-android/src/main/java/org/mtransit/android/data/UISchedule.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
+@SuppressLint("KotlinPairNotCreated")
 public class UISchedule extends org.mtransit.android.commons.data.Schedule implements MTLog.Loggable {
 
 	private static final String LOG_TAG = UISchedule.class.getSimpleName();
@@ -341,7 +342,7 @@ public class UISchedule extends org.mtransit.android.commons.data.Schedule imple
 	private long scheduleStringTimestamp = -1L;
 
 	@Nullable
-	private ArrayList<Pair<CharSequence, CharSequence>> statusStrings = null;
+	private Pair<CharSequence, CharSequence> statusStrings = null;
 
 	private long statusStringsTimestamp = -1L;
 
@@ -989,7 +990,7 @@ public class UISchedule extends org.mtransit.android.commons.data.Schedule imple
 	// STATUS
 
 	@Nullable
-	public ArrayList<Pair<CharSequence, CharSequence>> getStatus(
+	public Pair<CharSequence, CharSequence> getStatus(
 			@NonNull Context context,
 			long after,
 			@Nullable Long optMinCoverageInMs,
@@ -1014,12 +1015,12 @@ public class UISchedule extends org.mtransit.android.commons.data.Schedule imple
 			@Nullable ServiceUpdates serviceUpdates
 	) {
 		if (isNoData()) { // NO DATA
-			this.statusStrings = new ArrayList<>(); // 'no data' status is never displayed
+			this.statusStrings = new Pair<>(null, null); // 'no data' status is never displayed
 			this.statusStringsTimestamp = after;
 			return;
 		}
-		if (isNoPickup()) { // DESCENT ONLY
-			if (this.statusStrings == null || this.statusStrings.isEmpty()) {
+		if (isNoPickup()) { // NO PICKUP
+			if (this.statusStrings == null) {
 				generateStatusStringsNoPickup(context);
 			} // ELSE descent only already set
 			this.statusStringsTimestamp = after;
@@ -1038,8 +1039,8 @@ public class UISchedule extends org.mtransit.android.commons.data.Schedule imple
 			return;
 		}
 		CollectionUtils.removeIfNN(nextTimestamps, Timestamp::isNoPickup);
-		if (nextTimestamps.isEmpty()) { // DESCENT ONLY SERVICE
-			if (this.statusStrings == null || this.statusStrings.isEmpty()) {
+		if (nextTimestamps.isEmpty()) { // NO PICKUP SERVICE
+			if (this.statusStrings == null) {
 				generateStatusStringsNoPickup(context);
 			} // ELSE descent only already set
 			this.statusStringsTimestamp = after;
@@ -1191,8 +1192,7 @@ public class UISchedule extends org.mtransit.android.commons.data.Schedule imple
 			line1CS = decorateCancelled(nextTimestamp, line1CS, serviceUpdates);
 			if (line2CS != null) line2CS = decorateCancelled(nextTimestamp, line2CS, serviceUpdates);
 		}
-		this.statusStrings = new ArrayList<>();
-		this.statusStrings.add(new Pair<>(line1CS, line2CS));
+		this.statusStrings = new Pair<>(line1CS, line2CS);
 	}
 
 	@Nullable
@@ -1254,16 +1254,16 @@ public class UISchedule extends org.mtransit.android.commons.data.Schedule imple
 			CharSequence cs1,
 			CharSequence cs2
 	) {
-		this.statusStrings = new ArrayList<>();
-		this.statusStrings.add(new Pair<>(//
-				SpanUtils.setAll(cs1, //
-						getStatusStringTextAppearance(context), //
-						STATUS_FONT, //
-						getStatusStringsTextColor1(context)), //
-				SpanUtils.setAll(cs2, //
-						getStatusStringTextAppearance(context), //
-						STATUS_FONT, //
-						getStatusStringsTextColor2(context))));
+		this.statusStrings = new Pair<>(
+				SpanUtils.setAll(cs1,
+						getStatusStringTextAppearance(context),
+						STATUS_FONT,
+						getStatusStringsTextColor1(context)),
+				SpanUtils.setAll(cs2,
+						getStatusStringTextAppearance(context),
+						STATUS_FONT,
+						getStatusStringsTextColor2(context))
+		);
 	}
 
 	static class TimeSections {

--- a/app-android/src/main/java/org/mtransit/android/data/UISchedule.java
+++ b/app-android/src/main/java/org/mtransit/android/data/UISchedule.java
@@ -345,7 +345,7 @@ public class UISchedule extends org.mtransit.android.commons.data.Schedule imple
 
 	private long statusStringsTimestamp = -1L;
 
-	private UISchedule(@NonNull org.mtransit.android.commons.data.Schedule schedule) {
+	protected UISchedule(@NonNull org.mtransit.android.commons.data.Schedule schedule) {
 		this(
 				schedule,
 				schedule.getProviderPrecisionInMs(),
@@ -367,18 +367,29 @@ public class UISchedule extends org.mtransit.android.commons.data.Schedule imple
 			long readFromSourceAtInMs,
 			long providerPrecisionInMs,
 			boolean noPickup,
-			@Nullable String sourceLabel,
-			boolean hasData
+			@Nullable String sourceLabel
 	) {
-		super(id, targetUUID, lastUpdateInMs, maxValidityInMs, readFromSourceAtInMs, providerPrecisionInMs, noPickup, sourceLabel, hasData);
+		this(id, targetUUID, lastUpdateInMs, maxValidityInMs, readFromSourceAtInMs, providerPrecisionInMs, noPickup, sourceLabel, false);
+	}
+
+	private UISchedule(
+			@Nullable Integer id,
+			@NonNull String targetUUID,
+			long lastUpdateInMs,
+			long maxValidityInMs,
+			long readFromSourceAtInMs,
+			long providerPrecisionInMs,
+			boolean noPickup,
+			@Nullable String sourceLabel,
+			boolean noData
+	) {
+		super(id, targetUUID, lastUpdateInMs, maxValidityInMs, readFromSourceAtInMs, providerPrecisionInMs, noPickup, sourceLabel, noData);
 	}
 
 	@Nullable
 	public static UISchedule fromCursorWithExtra(@NonNull Cursor cursor) {
 		org.mtransit.android.commons.data.Schedule schedule = org.mtransit.android.commons.data.Schedule.fromCursorWithExtra(cursor);
-		if (schedule == null) {
-			return null;
-		}
+		if (schedule == null) return null;
 		return new UISchedule(schedule);
 	}
 
@@ -1002,7 +1013,7 @@ public class UISchedule extends org.mtransit.android.commons.data.Schedule imple
 			@Nullable Integer optMaxCount,
 			@Nullable ServiceUpdates serviceUpdates
 	) {
-		if (!hasData()) { // NO DATA
+		if (isNoData()) { // NO DATA
 			this.statusStrings = new ArrayList<>(); // nothing to show
 			this.statusStringsTimestamp = after;
 			return;

--- a/app-android/src/main/java/org/mtransit/android/data/UIScheduleExt.kt
+++ b/app-android/src/main/java/org/mtransit/android/data/UIScheduleExt.kt
@@ -49,3 +49,5 @@ data class DetailsNextDepartures(
         fun makeTextOnly(timeText: CharSequence) = DetailsNextDepartures(timeText = timeText)
     }
 }
+
+fun Schedule.toUI() = UISchedule(this)

--- a/app-android/src/main/java/org/mtransit/android/data/UIScheduleExt.kt
+++ b/app-android/src/main/java/org/mtransit/android/data/UIScheduleExt.kt
@@ -10,6 +10,19 @@ import kotlin.math.roundToLong
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.DurationUnit
+import androidx.core.util.Pair as androidXPair
+
+fun UISchedule.getStatusK(
+    context: Context,
+    after: Long,
+    minCoverageInMs: Long? = null,
+    maxCoverageInMs: Long? = null,
+    minCount: Int? = null,
+    maxCount: Int? = null,
+    serviceUpdates: ServiceUpdates? = null,
+): androidXPair<CharSequence?, CharSequence?>? = this.getStatus(
+    context, after, minCoverageInMs, maxCoverageInMs, minCount, maxCount, serviceUpdates
+)
 
 fun ServiceUpdates?.findTripServiceUpdate(tripId: String?): ServiceUpdate? {
     tripId ?: return null

--- a/app-android/src/main/java/org/mtransit/android/provider/ModuleProvider.java
+++ b/app-android/src/main/java/org/mtransit/android/provider/ModuleProvider.java
@@ -520,8 +520,7 @@ public class ModuleProvider extends AgencyProvider implements POIProviderContrac
 				appInstalled,
 				appEnabled,
 				updateAvailable,
-				context.getString(org.mtransit.android.commons.R.string.google_play),
-				true
+				context.getString(org.mtransit.android.commons.R.string.google_play)
 		);
 	}
 

--- a/app-android/src/main/java/org/mtransit/android/ui/schedule/ScheduleAdapter.kt
+++ b/app-android/src/main/java/org/mtransit/android/ui/schedule/ScheduleAdapter.kt
@@ -124,9 +124,7 @@ class ScheduleAdapter :
 
     var timestamps: List<Schedule.Timestamp>? = null
         set(newValue) {
-            if (field == newValue) {
-                return
-            }
+            if (field == newValue) return
             field = newValue
             updateTimes()
         }
@@ -348,10 +346,10 @@ class ScheduleAdapter :
         this.nextTimestamp = null
     }
 
-    fun isReady() = this.timesCount != null
+    val isReady get() = this.timesCount != null
 
     override fun getItemCount(): Int {
-        return if (!isReady()) 0
+        return if (!isReady) 0
         else
             (this.timesCount ?: 0) + // times
                     dayToHourToTimestamps.size + // day separator

--- a/app-android/src/main/java/org/mtransit/android/ui/schedule/ScheduleFragment.kt
+++ b/app-android/src/main/java/org/mtransit/android/ui/schedule/ScheduleFragment.kt
@@ -197,8 +197,8 @@ class ScheduleFragment : ABFragment(R.layout.fragment_schedule_infinite),
                         list.scrollToPosition(scrollPosition)
                     }
                 }
-                loadingLayout.isVisible = !listAdapter.isReady()
-                list.isVisible = listAdapter.isReady()
+                loadingLayout.isVisible = !listAdapter.isReady
+                list.isVisible = listAdapter.isReady
             }
         }
         viewModel.showAccessibility.observe(viewLifecycleOwner) { showAccessibility ->

--- a/app-android/src/main/java/org/mtransit/android/ui/schedule/ScheduleViewModel.kt
+++ b/app-android/src/main/java/org/mtransit/android/ui/schedule/ScheduleViewModel.kt
@@ -188,7 +188,7 @@ class ScheduleViewModel @Inject constructor(
                 hasProviderTimestampsReturned = true
                 if (scheduleTimestamps.timestampsCount > 0) {
                     _scheduleSourceLabel.postValue(scheduleTimestamps.sourceLabel)
-                    viewModelScope.launch(Dispatchers.Main) {
+                    withContext(Dispatchers.Main) {
                         savedStateHandle[LOCAL_TIME_ZONE_ID] =
                             scheduleTimestamps.timestamps.firstNotNullOfOrNull { it.localTimeZoneId }
                                 ?: TimeZone.getDefault().id // must set a timezone to display calendar
@@ -203,7 +203,7 @@ class ScheduleViewModel @Inject constructor(
             }
         }
         _scheduleSourceLabel.postValue(null)
-        viewModelScope.launch(Dispatchers.Main) {
+        withContext(Dispatchers.Main) {
             savedStateHandle[LOCAL_TIME_ZONE_ID] = TimeZone.getDefault().id // empty list must set a timezone to display calendar
         }
         return emptyList() // loaded (not loading) == no service today

--- a/app-android/src/main/java/org/mtransit/android/ui/schedule/ScheduleViewModel.kt
+++ b/app-android/src/main/java/org/mtransit/android/ui/schedule/ScheduleViewModel.kt
@@ -99,8 +99,7 @@ class ScheduleViewModel @Inject constructor(
 
     private val _startsAtDaysBefore = savedStateHandle.getLiveDataDistinct<Int?>(EXTRA_START_AT_DAYS_BEFORE)
     private val _endsAtDaysAfter = savedStateHandle.getLiveDataDistinct<Int?>(EXTRA_END_AT_DAYS_AFTER)
-    private val _localTimeZoneId = savedStateHandle.getLiveData<String?>(LOCAL_TIME_ZONE_ID)
-    private val localTimeZoneId: LiveData<String?> = _localTimeZoneId.distinctUntilChanged()
+    private val localTimeZoneId = savedStateHandle.getLiveDataDistinct<String?>(LOCAL_TIME_ZONE_ID)
 
     val localTimeZone: LiveData<TimeZone?> = localTimeZoneId.map { timeZoneId ->
         timeZoneId?.let { TimeZone.getTimeZone(it) }
@@ -189,8 +188,10 @@ class ScheduleViewModel @Inject constructor(
                 hasProviderTimestampsReturned = true
                 if (scheduleTimestamps.timestampsCount > 0) {
                     _scheduleSourceLabel.postValue(scheduleTimestamps.sourceLabel)
-                    scheduleTimestamps.timestamps.firstNotNullOfOrNull { it.localTimeZoneId }?.let { localTimeZoneId ->
-                        this._localTimeZoneId.postValue(localTimeZoneId)
+                    viewModelScope.launch(Dispatchers.Main) {
+                        savedStateHandle[LOCAL_TIME_ZONE_ID] =
+                            scheduleTimestamps.timestamps.firstNotNullOfOrNull { it.localTimeZoneId }
+                                ?: TimeZone.getDefault().id // must set a timezone to display calendar
                     }
                     return scheduleTimestamps.timestamps
                 }
@@ -202,6 +203,9 @@ class ScheduleViewModel @Inject constructor(
             }
         }
         _scheduleSourceLabel.postValue(null)
+        viewModelScope.launch(Dispatchers.Main) {
+            savedStateHandle[LOCAL_TIME_ZONE_ID] = TimeZone.getDefault().id // empty list must set a timezone to display calendar
+        }
         return emptyList() // loaded (not loading) == no service today
     }
 

--- a/app-android/src/main/java/org/mtransit/android/ui/schedule/ScheduleViewModel.kt
+++ b/app-android/src/main/java/org/mtransit/android/ui/schedule/ScheduleViewModel.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.mtransit.android.commons.ColorUtils
 import org.mtransit.android.commons.MTLog
 import org.mtransit.android.commons.data.RouteDirectionStop

--- a/app-android/src/main/java/org/mtransit/android/ui/view/poi/status/POICommonStatusViewHolder.kt
+++ b/app-android/src/main/java/org/mtransit/android/ui/view/poi/status/POICommonStatusViewHolder.kt
@@ -9,7 +9,6 @@ import org.mtransit.android.R
 import org.mtransit.android.commons.MTLog
 import org.mtransit.android.commons.data.POI
 import org.mtransit.android.commons.data.POIStatus
-import org.mtransit.android.commons.data.ServiceUpdate
 import org.mtransit.android.commons.data.ServiceUpdates
 import org.mtransit.android.data.POIManager
 
@@ -17,7 +16,7 @@ interface POICommonStatusViewHolder<VB : ViewBinding?, STATUS : POIStatus?> {
 
     @CallSuper
     fun bind(status: STATUS?, dataProvider: POIStatusDataProvider, serviceUpdates: ServiceUpdates?) {
-        statusV.isVisible = status != null
+        setStatusVisible(status != null)
     }
 
     fun setStatusVisible(visible: Boolean) {

--- a/app-android/src/main/java/org/mtransit/android/ui/view/poi/status/POIScheduleViewHolder.kt
+++ b/app-android/src/main/java/org/mtransit/android/ui/view/poi/status/POIScheduleViewHolder.kt
@@ -46,8 +46,9 @@ data class POIScheduleViewHolder(
     }
 
     override fun bind(status: Schedule?, dataProvider: POIStatusDataProvider, serviceUpdates: ServiceUpdates?) {
-        super.bind(status?.takeIf { !it.isNoData }, dataProvider, serviceUpdates)
-        val schedule = status as? UISchedule ?: return
+        val statusWithData = status?.takeIf { !it.isNoData } // 'no data' status is never displayed
+        super.bind(statusWithData, dataProvider, serviceUpdates)
+        val schedule = statusWithData as? UISchedule ?: return
         binding.apply {
             schedule.getStatus(
                 context,

--- a/app-android/src/main/java/org/mtransit/android/ui/view/poi/status/POIScheduleViewHolder.kt
+++ b/app-android/src/main/java/org/mtransit/android/ui/view/poi/status/POIScheduleViewHolder.kt
@@ -45,25 +45,17 @@ data class POIScheduleViewHolder(
 
     override fun bind(status: Schedule?, dataProvider: POIStatusDataProvider, serviceUpdates: ServiceUpdates?) {
         super.bind(status, dataProvider, serviceUpdates)
-        status?.let { schedule ->
-            binding.apply {
-                var line1CS: CharSequence? = null
-                var line2CS: CharSequence? = null
-                if (schedule is UISchedule) {
-                    val lines = schedule.getStatus(
-                        context,
-                        dataProvider.nowToTheMinute,
-                        TimeUnit.MINUTES.toMillis(30L),
-                        null,
-                        10,
-                        null,
-                        serviceUpdates,
-                    )
-                    if (!lines.isNullOrEmpty()) {
-                        line1CS = lines[0].first
-                        line2CS = lines[0].second
-                    }
-                }
+        val schedule = status as? UISchedule ?: return
+        binding.apply {
+            schedule.getStatus(
+                context,
+                dataProvider.nowToTheMinute,
+                TimeUnit.MINUTES.toMillis(30L),
+                null,
+                10,
+                null,
+                serviceUpdates,
+            )?.firstOrNull()?.let { (line1CS, line2CS) ->
                 dataNextLine1.setText(line1CS, TextView.BufferType.SPANNABLE)
                 dataNextLine2.setText(line2CS, TextView.BufferType.SPANNABLE)
                 dataNextLine2.isVisible = !line2CS.isNullOrEmpty()

--- a/app-android/src/main/java/org/mtransit/android/ui/view/poi/status/POIScheduleViewHolder.kt
+++ b/app-android/src/main/java/org/mtransit/android/ui/view/poi/status/POIScheduleViewHolder.kt
@@ -60,7 +60,6 @@ data class POIScheduleViewHolder(
                 minCount = 10,
                 serviceUpdates = serviceUpdates,
             ) ?: androidXPair<CharSequence?, CharSequence?>(null, null)
-            //     MTLog.d(this, "bind() > '$line1CS', '$line2CS' - $uuid")
             dataNextLine1.setText(line1CS, TextView.BufferType.SPANNABLE)
             dataNextLine2.setText(line2CS, TextView.BufferType.SPANNABLE)
             dataNextLine2.isVisible = !line2CS.isNullOrEmpty()

--- a/app-android/src/main/java/org/mtransit/android/ui/view/poi/status/POIScheduleViewHolder.kt
+++ b/app-android/src/main/java/org/mtransit/android/ui/view/poi/status/POIScheduleViewHolder.kt
@@ -11,9 +11,11 @@ import org.mtransit.android.commons.data.Schedule
 import org.mtransit.android.commons.data.ServiceUpdates
 import org.mtransit.android.data.POIManager
 import org.mtransit.android.data.UISchedule
+import org.mtransit.android.data.getStatusK
 import org.mtransit.android.databinding.LayoutPoiStatusScheduleBinding
 import org.mtransit.android.ui.view.common.context
 import java.util.concurrent.TimeUnit
+import androidx.core.util.Pair as androidXPair
 
 data class POIScheduleViewHolder(
     override var uuid: String,
@@ -46,24 +48,23 @@ data class POIScheduleViewHolder(
     }
 
     override fun bind(status: Schedule?, dataProvider: POIStatusDataProvider, serviceUpdates: ServiceUpdates?) {
-        val statusWithData = status?.takeIf { !it.isNoData } // 'no data' status is never displayed
-        super.bind(statusWithData, dataProvider, serviceUpdates)
-        val schedule = statusWithData as? UISchedule ?: return
+        val scheduleWithData = (status as? UISchedule)?.takeIf { !it.isNoData } // 'no data' status is never displayed
+        super.bind(scheduleWithData, dataProvider, serviceUpdates)
+        scheduleWithData ?: return
         binding.apply {
-            schedule.getStatus(
-                context,
-                dataProvider.nowToTheMinute,
-                TimeUnit.MINUTES.toMillis(30L),
-                null,
-                10,
-                null,
-                serviceUpdates,
-            )?.firstOrNull()?.let { (line1CS, line2CS) ->
-                dataNextLine1.setText(line1CS, TextView.BufferType.SPANNABLE)
-                dataNextLine2.setText(line2CS, TextView.BufferType.SPANNABLE)
-                dataNextLine2.isVisible = !line2CS.isNullOrEmpty()
-                super.setStatusVisible(visible = !line1CS.isNullOrEmpty())
-            }
+            //noinspection KotlinPairNotCreated
+            val (line1CS, line2CS) = scheduleWithData.getStatusK(
+                context = context,
+                after = dataProvider.nowToTheMinute,
+                minCoverageInMs = TimeUnit.MINUTES.toMillis(30L),
+                minCount = 10,
+                serviceUpdates = serviceUpdates,
+            ) ?: androidXPair<CharSequence?, CharSequence?>(null, null)
+            //     MTLog.d(this, "bind() > '$line1CS', '$line2CS' - $uuid")
+            dataNextLine1.setText(line1CS, TextView.BufferType.SPANNABLE)
+            dataNextLine2.setText(line2CS, TextView.BufferType.SPANNABLE)
+            dataNextLine2.isVisible = !line2CS.isNullOrEmpty()
+            super.setStatusVisible(visible = !line1CS.isNullOrEmpty())
         }
     }
 

--- a/app-android/src/main/java/org/mtransit/android/ui/view/poi/status/POIScheduleViewHolder.kt
+++ b/app-android/src/main/java/org/mtransit/android/ui/view/poi/status/POIScheduleViewHolder.kt
@@ -46,7 +46,7 @@ data class POIScheduleViewHolder(
     }
 
     override fun bind(status: Schedule?, dataProvider: POIStatusDataProvider, serviceUpdates: ServiceUpdates?) {
-        super.bind(status, dataProvider, serviceUpdates)
+        super.bind(status?.takeIf { !it.isNoData }, dataProvider, serviceUpdates)
         val schedule = status as? UISchedule ?: return
         binding.apply {
             schedule.getStatus(

--- a/app-android/src/main/java/org/mtransit/android/ui/view/poi/status/POIScheduleViewHolder.kt
+++ b/app-android/src/main/java/org/mtransit/android/ui/view/poi/status/POIScheduleViewHolder.kt
@@ -2,6 +2,8 @@ package org.mtransit.android.ui.view.poi.status
 
 import android.view.View
 import android.widget.TextView
+import androidx.core.util.component1
+import androidx.core.util.component2
 import androidx.core.view.isVisible
 import org.mtransit.android.commons.MTLog
 import org.mtransit.android.commons.data.POIStatus

--- a/app-android/src/test/java/org/mtransit/android/commons/data/RouteDirectionStopTestFixtures.kt
+++ b/app-android/src/test/java/org/mtransit/android/commons/data/RouteDirectionStopTestFixtures.kt
@@ -1,0 +1,41 @@
+package org.mtransit.android.commons.data
+
+fun makeRDS(
+    authority: String = "authority",
+    routeId: Long = 1L,
+    routeOriginalIdHash: Int? = routeId.toString().hashCode(),
+    routeType: Int = 3,
+    originalDirectionId: Int? = 1,
+    directionId: Long = originalDirectionId?.let { routeId * 100L + it } ?: (routeId * 100L + 9L),
+    stopId: Int = 1,
+    stopOriginalIdHash: Int? = stopId.toString().hashCode() // stopId, // "$stopId".hashCode()
+) = RouteDirectionStop(
+    1,
+    Route(
+        authority,
+        routeId,
+        "#$routeId",
+        "route $routeId",
+        "color",
+        routeOriginalIdHash,
+        routeType,
+    ),
+    Direction(
+        authority,
+        directionId,
+        Direction.HEADSIGN_TYPE_STRING,
+        "Head-Sign $originalDirectionId",
+        routeId,
+    ),
+    Stop(
+        stopId,
+        "#$stopId",
+        "Stop #$stopId",
+        1.0,
+        2.0,
+        Accessibility.DEFAULT,
+        stopOriginalIdHash,
+    ),
+    false,
+    false,
+)

--- a/app-android/src/test/java/org/mtransit/android/data/POIManagerTest.kt
+++ b/app-android/src/test/java/org/mtransit/android/data/POIManagerTest.kt
@@ -1,0 +1,88 @@
+package org.mtransit.android.data
+
+import org.mtransit.android.commons.TimeUtils
+import org.mtransit.android.commons.data.RouteDirectionStop
+import org.mtransit.android.commons.data.Schedule
+import org.mtransit.android.commons.data.makeRDS
+import org.mtransit.android.commons.data.makeSchedule
+import org.mtransit.android.commons.data.toScheduleTimestamp
+import org.mtransit.android.commons.millisToInstant
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
+
+class POIManagerTest {
+
+    companion object {
+        private const val LOCAL_TZ_ID: String = "America/Montreal"
+
+        private const val NOW_MS = 123456789_000L
+        private val NOW = NOW_MS.millisToInstant()
+    }
+
+    @BeforeTest
+    fun setUp() {
+        TimeUtils.setOverrideCurrentTimeMillis(NOW_MS)
+    }
+
+    @Test
+    fun test_setStatus() {
+        val rds = makeRDS()
+        // from no status -> status w/ no data
+        rds.toPOIM(status = null).apply {
+            setStatus(rds.mkSchedule(hasData = false))
+        }.statusOrNull?.let { result ->
+            assertNotNull(result)
+            assertIs<Schedule>(result)
+            assertFalse(result.hasData())
+        }
+        // from staus no data -> status useful
+        rds.toPOIM(status = rds.mkSchedule(hasData = false)).apply {
+            setStatus(rds.mkSchedule(hasData = true, timestamps = mkTimestampsUseful()))
+        }.statusOrNull?.let { result ->
+            assertNotNull(result)
+            assertIs<Schedule>(result)
+            assertTrue(result.hasData())
+            assertTrue(result.isUseful)
+        }
+        // from status useful -> ignore new no data
+        rds.toPOIM(status = rds.mkSchedule(hasData = true, timestamps = mkTimestampsUseful())).apply {
+            setStatus(rds.mkSchedule(hasData = false))
+        }.statusOrNull?.let { result ->
+            assertNotNull(result)
+            assertIs<Schedule>(result)
+            assertTrue(result.hasData())
+            assertTrue(result.isUseful)
+        }
+    }
+
+    private fun mkTimestampsUseful() = listOf(mkTime(NOW + 1.minutes))
+
+    private fun RouteDirectionStop.mkSchedule(
+        lastUpdateInMs: Long = NOW_MS,
+        validityInMs: Long = 1.hours.inWholeMilliseconds,
+        readFromSourceAtInMs: Long = NOW_MS,
+        providerPrecisionInMs: Long = 1.minutes.inWholeMilliseconds,
+        sourceLabel: String = "test_source",
+        hasData: Boolean = true,
+        timestamps: List<Schedule.Timestamp>? = null,
+    ) = makeSchedule(
+        lastUpdateInMs = lastUpdateInMs,
+        validityInMs = validityInMs,
+        readFromSourceAtInMs = readFromSourceAtInMs,
+        providerPrecisionInMs = providerPrecisionInMs,
+        sourceLabel = sourceLabel,
+        hasData = hasData
+    ).apply {
+        timestamps?.let { setTimestampsAndSort(it) }
+    }
+
+    private fun mkTime(time: Instant, tripId: String? = null, stopSeq: Int? = null, arrival: Instant? = null) =
+        time.toScheduleTimestamp(LOCAL_TZ_ID, arrival, tripId, stopSeq)
+}

--- a/app-android/src/test/java/org/mtransit/android/data/POIManagerTest.kt
+++ b/app-android/src/test/java/org/mtransit/android/data/POIManagerTest.kt
@@ -31,34 +31,62 @@ class POIManagerTest {
         TimeUtils.setOverrideCurrentTimeMillis(NOW_MS)
     }
 
+    private val rds get() =  makeRDS()
+
     @Test
-    fun test_setStatus() {
-        val rds = makeRDS()
-        // from no status -> status w/ no data
+    fun test_setStatus_fromNothing_toNoData() {
         rds.toPOIM(status = null).apply {
-            setStatus(rds.mkSchedule(hasData = false))
-        }.statusOrNull?.let { result ->
+            setStatus(rds.mkSchedule(noData = true))
+        }.statusOrNull.let { result ->
             assertNotNull(result)
             assertIs<Schedule>(result)
-            assertFalse(result.hasData())
+            assertFalse(!result.isNoData)
         }
-        // from staus no data -> status useful
-        rds.toPOIM(status = rds.mkSchedule(hasData = false)).apply {
-            setStatus(rds.mkSchedule(hasData = true, timestamps = mkTimestampsUseful()))
-        }.statusOrNull?.let { result ->
+    }
+
+    @Test
+    fun test_setStatus_fromNoData_toUseful() {
+        rds.toPOIM(status = rds.mkSchedule(noData = true)).apply {
+            setStatus(rds.mkSchedule(timestamps = mkTimestampsUseful()))
+        }.statusOrNull.let { result ->
             assertNotNull(result)
             assertIs<Schedule>(result)
-            assertTrue(result.hasData())
+            assertFalse(result.isNoData)
             assertTrue(result.isUseful)
         }
-        // from status useful -> ignore new no data
-        rds.toPOIM(status = rds.mkSchedule(hasData = true, timestamps = mkTimestampsUseful())).apply {
-            setStatus(rds.mkSchedule(hasData = false))
-        }.statusOrNull?.let { result ->
+    }
+
+    @Test
+    fun test_setStatus_fromUseful_toNoData() {
+        rds.toPOIM(status = rds.mkSchedule(timestamps = mkTimestampsUseful())).apply {
+            setStatus(rds.mkSchedule(noData = true))
+        }.statusOrNull.let { result ->
             assertNotNull(result)
             assertIs<Schedule>(result)
-            assertTrue(result.hasData())
+            assertFalse(result.isNoData)
             assertTrue(result.isUseful)
+        }
+    }
+
+    @Test
+    fun test_setStatus_fromNoService_toNoData() {
+        rds.toPOIM(status = rds.mkSchedule()).apply {
+            setStatus(rds.mkSchedule(noData = true))
+        }.statusOrNull.let { result ->
+            assertNotNull(result)
+            assertIs<Schedule>(result)
+            assertFalse(result.isNoData)
+        }
+    }
+
+    @Test
+    fun test_setStatus_fromNoData_toNoService() {
+        rds.toPOIM(status = rds.mkSchedule(noData = true)).apply {
+            setStatus(rds.mkSchedule())
+        }.statusOrNull.let { result ->
+            assertNotNull(result)
+            assertIs<Schedule>(result)
+            assertFalse(result.isNoData)
         }
     }
 
@@ -70,7 +98,7 @@ class POIManagerTest {
         readFromSourceAtInMs: Long = NOW_MS,
         providerPrecisionInMs: Long = 1.minutes.inWholeMilliseconds,
         sourceLabel: String = "test_source",
-        hasData: Boolean = true,
+        noData: Boolean = false,
         timestamps: List<Schedule.Timestamp>? = null,
     ) = makeSchedule(
         lastUpdateInMs = lastUpdateInMs,
@@ -78,10 +106,10 @@ class POIManagerTest {
         readFromSourceAtInMs = readFromSourceAtInMs,
         providerPrecisionInMs = providerPrecisionInMs,
         sourceLabel = sourceLabel,
-        hasData = hasData
+        noData = noData
     ).apply {
         timestamps?.let { setTimestampsAndSort(it) }
-    }
+    }.toUI()
 
     private fun mkTime(time: Instant, tripId: String? = null, stopSeq: Int? = null, arrival: Instant? = null) =
         time.toScheduleTimestamp(LOCAL_TZ_ID, arrival, tripId, stopSeq)

--- a/app-android/src/test/java/org/mtransit/android/data/POIManagerTest.kt
+++ b/app-android/src/test/java/org/mtransit/android/data/POIManagerTest.kt
@@ -40,7 +40,7 @@ class POIManagerTest {
         }.statusOrNull.let { result ->
             assertNotNull(result)
             assertIs<Schedule>(result)
-            assertFalse(!result.isNoData)
+            assertTrue(result.isNoData)
         }
     }
 

--- a/app-android/src/test/java/org/mtransit/android/data/UIScheduleTest.java
+++ b/app-android/src/test/java/org/mtransit/android/data/UIScheduleTest.java
@@ -197,7 +197,7 @@ public class UIScheduleTest {
 	@Test
 	public void testGetNextTimestamps() {
 		// Arrange
-		UISchedule schedule = new UISchedule(null, TARGET_UUID, -1L, -1L, -1L, PROVIDER_PRECISION_IN_MS, false, null, true);
+		UISchedule schedule = new UISchedule(null, TARGET_UUID, -1L, -1L, -1L, PROVIDER_PRECISION_IN_MS, false, null);
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(-5L)));
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(-1L)));
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(7L)));
@@ -214,7 +214,7 @@ public class UIScheduleTest {
 	@Test
 	public void testGetStatusNextTimestampsWithUsefulLast() {
 		// Arrange
-		UISchedule schedule = new UISchedule(null, TARGET_UUID, -1L, -1L, -1L, PROVIDER_PRECISION_IN_MS, false, null, true);
+		UISchedule schedule = new UISchedule(null, TARGET_UUID, -1L, -1L, -1L, PROVIDER_PRECISION_IN_MS, false, null);
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(-2L)));
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(7L)));
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(13L)));
@@ -231,7 +231,7 @@ public class UIScheduleTest {
 	@Test
 	public void testGetStatusNextTimestampsWithUselessLast() {
 		// Arrange
-		UISchedule schedule = new UISchedule(null, TARGET_UUID, -1L, -1L, -1L, PROVIDER_PRECISION_IN_MS, false, null, true);
+		UISchedule schedule = new UISchedule(null, TARGET_UUID, -1L, -1L, -1L, PROVIDER_PRECISION_IN_MS, false, null);
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(-10L)));
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(7L)));
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(13L)));
@@ -248,7 +248,7 @@ public class UIScheduleTest {
 	@Test
 	public void testGetStatusNextTimestampsWithMultipleUsefulLast() {
 		// Arrange
-		UISchedule schedule = new UISchedule(null, TARGET_UUID, -1L, -1L, -1L, PROVIDER_PRECISION_IN_MS, false, null, true);
+		UISchedule schedule = new UISchedule(null, TARGET_UUID, -1L, -1L, -1L, PROVIDER_PRECISION_IN_MS, false, null);
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(-3L)));
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(-1L)));
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(7L)));
@@ -266,7 +266,7 @@ public class UIScheduleTest {
 	@Test
 	public void testGetStatusNextTimestampsWithUsefulLastDuplicates() {
 		// Arrange
-		UISchedule schedule = new UISchedule(null, TARGET_UUID, -1L, -1L, -1L, PROVIDER_PRECISION_IN_MS, false, null, true);
+		UISchedule schedule = new UISchedule(null, TARGET_UUID, -1L, -1L, -1L, PROVIDER_PRECISION_IN_MS, false, null);
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(-2L)));
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(-1L)));
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(-1L)));
@@ -286,7 +286,7 @@ public class UIScheduleTest {
 	@Test
 	public void testGetStatusNextTimestampsWithUsefulNextDuplicates() {
 		// Arrange
-		UISchedule schedule = new UISchedule(null, TARGET_UUID, -1L, -1L, -1L, PROVIDER_PRECISION_IN_MS, false, null, true);
+		UISchedule schedule = new UISchedule(null, TARGET_UUID, -1L, -1L, -1L, PROVIDER_PRECISION_IN_MS, false, null);
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(-20L)));
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(7L)));
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(7L)));
@@ -305,7 +305,7 @@ public class UIScheduleTest {
 	@Test
 	public void testGetStatusNextTimestampsWithUsefulNearDuplicates() {
 		// Arrange
-		UISchedule schedule = new UISchedule(null, TARGET_UUID, -1L, -1L, -1L, PROVIDER_PRECISION_IN_MS, false, null, true);
+		UISchedule schedule = new UISchedule(null, TARGET_UUID, -1L, -1L, -1L, PROVIDER_PRECISION_IN_MS, false, null);
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(-1L) - 1L));
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(-1L)));
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(7L)));
@@ -325,7 +325,7 @@ public class UIScheduleTest {
 	@Test
 	public void testGetStatusNextTimestampsWithUsefulNextNearDuplicates() {
 		// Arrange
-		UISchedule schedule = new UISchedule(null, TARGET_UUID, -1L, -1L, -1L, PROVIDER_PRECISION_IN_MS, false, null, true);
+		UISchedule schedule = new UISchedule(null, TARGET_UUID, -1L, -1L, -1L, PROVIDER_PRECISION_IN_MS, false, null);
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(-10L) - 1L));
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(-10L)));
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(7L)));
@@ -346,7 +346,7 @@ public class UIScheduleTest {
 	@Test
 	public void testGetStatusNextTimestampsWithBusAtStop() { // fails if timestamp times are NOT to the minute
 		// Arrange
-		UISchedule schedule = new UISchedule(null, TARGET_UUID, -1L, -1L, -1L, PROVIDER_PRECISION_IN_MS, false, null, true);
+		UISchedule schedule = new UISchedule(null, TARGET_UUID, -1L, -1L, -1L, PROVIDER_PRECISION_IN_MS, false, null);
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(-1L)));
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(0L)));
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(3L)));
@@ -366,7 +366,7 @@ public class UIScheduleTest {
 	@Test
 	public void testGetStatusNextTimestampsWithNearDuplicates() {
 		// Arrange
-		UISchedule schedule = new UISchedule(null, TARGET_UUID, -1L, -1L, -1L, PROVIDER_PRECISION_IN_MS, false, null, true);
+		UISchedule schedule = new UISchedule(null, TARGET_UUID, -1L, -1L, -1L, PROVIDER_PRECISION_IN_MS, false, null);
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(-2L)));
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(-1L)));
 		schedule.addTimestampWithoutSort(new Timestamp(NOW_TO_THE_MINUTE + TimeUnit.MINUTES.toMillis(2L)));


### PR DESCRIPTION
Example: GTFS-RT status already computed as "no data" (not in service) but GTFS static can return valid next departures in 2 days

- https://github.com/mtransitapps/commons-android/pull/173