### PR TITLE
Fix crash(es) in latest release

### DIFF
--- a/app-android/src/main/java/org/mtransit/android/ui/EdgeToEdge.kt
+++ b/app-android/src/main/java/org/mtransit/android/ui/EdgeToEdge.kt
@@ -138,11 +138,11 @@ fun Activity.setStatusBarsThemeEdgeToEdge(isDark: Boolean = isDarkMode(resources
 }
 
 @JvmOverloads
-fun View.applyStatusBarsHeightEdgeToEdge(@Px initialHeightPx: Int = 0) {
+fun View?.applyStatusBarsHeightEdgeToEdge(@Px initialHeightPx: Int = 0) {
     if (!UIFeatureFlags.F_EDGE_TO_EDGE) {
         return
     }
-    applyWindowInsetsEdgeToEdge(WindowInsetsCompat.Type.statusBars(), consumed = false) { insets ->
+    this?.applyWindowInsetsEdgeToEdge(WindowInsetsCompat.Type.statusBars(), consumed = false) { insets ->
         updateLayoutParams<ViewGroup.MarginLayoutParams> {
             height = initialHeightPx + insets.height
         }


### PR DESCRIPTION
Release: https://github.com/mtransitapps/mtransit-for-android/releases/tag/26.08.06_r5357

- https://console.firebase.google.com/project/montransitapps/crashlytics/app/android:org.mtransit.android/issues/dcc0b7ba9a3e7a8aa1e08c0f88559ffd
```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Class java.lang.Object.getClass()' on a null object reference
       at org.mtransit.android.ui.EdgeToEdgeKt.applyStatusBarsHeightEdgeToEdge(EdgeToEdge.kt:25)
       at org.mtransit.android.ui.fragment.ABFragment.onViewCreated(ABFragment.java:341)
       at org.mtransit.android.ui.home.HomeFragment.onViewCreated(HomeFragment.kt:220)
       at androidx.fragment.app.Fragment.performViewCreated(Fragment.java:3152)
```