### PR TITLE
GMA Next-Gen SDK migration (2nd try)

### DIFF
--- a/app-android/proguard-rules.pro
+++ b/app-android/proguard-rules.pro
@@ -35,3 +35,11 @@
 
 -dontwarn android.media.LoudnessCodecController$OnLoudnessCodecUpdateListener
 -dontwarn android.media.LoudnessCodecController
+
+# ADS: NEXT GEN SDK - START
+# Workaround for androidx.webkit prefetch crash in GMA SDK WebView URL prefetch flow.
+# The issue seems related to R8 shrinking/obfuscation of androidx.webkit /
+# Chromium support-lib boundary classes that are accessed reflectively.
+-keep class androidx.webkit.** { *; }
+-keep class org.chromium.support_lib_boundary.** { *; }
+# ADS: NEXT GEN SDK - END

--- a/app-android/src/main/java/org/mtransit/android/ad/AdManager.kt
+++ b/app-android/src/main/java/org/mtransit/android/ad/AdManager.kt
@@ -1,21 +1,21 @@
 package org.mtransit.android.ad
 
-// import com.google.android.libraries.ads.mobile.sdk.MobileAds #gmaNextGen
-// import com.google.android.libraries.ads.mobile.sdk.banner.AdSize #gmaNextGen
-// import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRequest #gmaNextGen
-// import com.google.android.libraries.ads.mobile.sdk.common.AdInspectorError #gmaNextGen
-// import com.google.android.libraries.ads.mobile.sdk.common.AdRequest #gmaNextGen
+// import com.google.ads.mediation.admob.AdMobAdapter // #gmaLegacy
+// import com.google.android.gms.ads.AdInspectorError // #gmaLegacy
+// import com.google.android.gms.ads.AdRequest // #gmaLegacy
+// import com.google.android.gms.ads.AdSize // #gmaLegacy
+// import com.google.android.gms.ads.MobileAds // #gmaLegacy
 import android.content.res.Configuration
 import android.os.Bundle
 import androidx.annotation.MainThread
 import androidx.annotation.WorkerThread
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.lifecycleScope
-import com.google.ads.mediation.admob.AdMobAdapter
-import com.google.android.gms.ads.AdInspectorError
-import com.google.android.gms.ads.AdRequest
-import com.google.android.gms.ads.AdSize
-import com.google.android.gms.ads.MobileAds
+import com.google.android.libraries.ads.mobile.sdk.MobileAds // #gmaNextGen
+import com.google.android.libraries.ads.mobile.sdk.banner.AdSize // #gmaNextGen
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRequest // #gmaNextGen
+import com.google.android.libraries.ads.mobile.sdk.common.AdInspectorError // #gmaNextGen
+import com.google.android.libraries.ads.mobile.sdk.common.AdRequest // #gmaNextGen
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -55,8 +55,8 @@ class AdManager @Inject internal constructor(
 
         fun getAdRequest(
             @Suppress("unused") adUnitId: String,
-            // ) = AdRequest.Builder(adUnitId).apply { #gmaNextGen
-        ) = AdRequest.Builder().apply {
+        ) = AdRequest.Builder(adUnitId).apply { // #gmaNextGen
+            // ) = AdRequest.Builder().apply { // #gmaLegacy
             AdConstants.KEYWORDS.forEach { addKeyword(it) }
         }.build()
 
@@ -64,13 +64,13 @@ class AdManager @Inject internal constructor(
             @Suppress("unused") adUnitId: String,
             @Suppress("unused") adSize: AdSize,
             collapsible: Boolean = false,
-            // ) = BannerAdRequest.Builder(adUnitId, adSize).apply { #gmaNextGen
-        ) = AdRequest.Builder().apply {
+        ) = BannerAdRequest.Builder(adUnitId, adSize).apply { // #gmaNextGen
+            // ) = AdRequest.Builder().apply { // #gmaLegacy
             AdConstants.KEYWORDS.forEach { addKeyword(it) }
             if (collapsible) {
-                // setGoogleExtrasBundle( #gmaNextGen
-                addNetworkExtrasBundle(
-                    AdMobAdapter::class.java,
+                setGoogleExtrasBundle( // #gmaNextGen
+                    // addNetworkExtrasBundle( // #gmaLegacy
+                    // AdMobAdapter::class.java, // #gmaLegacy
                     Bundle().apply {
                         putString("collapsible", "bottom")
                     }
@@ -197,8 +197,8 @@ class AdManager @Inject internal constructor(
     // endregion App open ads
 
     override fun openAdInspector(activity: IActivity) {
-        // MobileAds.openAdInspector { error: AdInspectorError? -> #gmaNextGen
-        MobileAds.openAdInspector(activity.requireActivity()) { error: AdInspectorError? ->
+        MobileAds.openAdInspector { error: AdInspectorError? -> // #gmaNextGen
+            // MobileAds.openAdInspector(activity.requireActivity()) { error: AdInspectorError? -> // #gmaLegacy
             if (error == null) {
                 logAdsD(this@AdManager, "Ad inspector closed.")
             } else {

--- a/app-android/src/main/java/org/mtransit/android/ad/GlobalAdManager.kt
+++ b/app-android/src/main/java/org/mtransit/android/ad/GlobalAdManager.kt
@@ -1,14 +1,14 @@
 package org.mtransit.android.ad
 
-// import com.google.android.libraries.ads.mobile.sdk.MobileAds #gmaNextGen
-// import com.google.android.libraries.ads.mobile.sdk.common.RequestConfiguration #gmaNextGen
-// import com.google.android.libraries.ads.mobile.sdk.initialization.InitializationConfig #gmaNextGen
+// import com.google.android.gms.ads.AdRequest // #gmaLegacy
+// import com.google.android.gms.ads.MobileAds // #gmaLegacy
+// import com.google.android.gms.ads.RequestConfiguration // #gmaLegacy
 import android.content.Context
 import androidx.annotation.WorkerThread
 import androidx.lifecycle.LiveData
-import com.google.android.gms.ads.AdRequest
-import com.google.android.gms.ads.MobileAds
-import com.google.android.gms.ads.RequestConfiguration
+import com.google.android.libraries.ads.mobile.sdk.MobileAds // #gmaNextGen
+import com.google.android.libraries.ads.mobile.sdk.common.RequestConfiguration // #gmaNextGen
+import com.google.android.libraries.ads.mobile.sdk.initialization.InitializationConfig // #gmaNextGen
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -166,16 +166,16 @@ class GlobalAdManager(
         RequestConfiguration.Builder()
             .setTestDeviceIds(
                 listOf(*context.resources.getStringArray(R.array.google_ads_test_devices_ids))
-                        + listOf(AdRequest.DEVICE_ID_EMULATOR)
-                // Android emulators are automatically configured as test devices. #gmaNextGen
+                // + listOf(AdRequest.DEVICE_ID_EMULATOR) // #gmaLegacy
+                // Android emulators are automatically configured as test devices. // #gmaNextGen
             )
             .build()
 
-    // private fun InitializationConfig.Builder.disableMediationAdapterInit(@Suppress("unused") context: Context, appId: String) { #gmaNextGen
-    private fun disableMediationAdapterInit(context: Context, appId: String) {
+    private fun InitializationConfig.Builder.disableMediationAdapterInit(@Suppress("unused") context: Context, appId: String) { // #gmaNextGen
+        // private fun disableMediationAdapterInit(context: Context, appId: String) { // #gmaLegacy
         if (appId.startsWith(GOOGLE_ADS_TEST_IDS_START_WITH)) {
-            // disableMediationAdapterInitialization() // all will fail/timeout #gmaNextGen
-            MobileAds.disableMediationAdapterInitialization(context) // all will fail/timeout
+            disableMediationAdapterInitialization() // all will fail/timeout  // #gmaNextGen
+            // MobileAds.disableMediationAdapterInitialization(context) // all will fail/timeout // #gmaLegacy
         }
     }
 
@@ -184,19 +184,18 @@ class GlobalAdManager(
         // https://developers.google.com/admob/android/next-gen/quick-start
         val context = activity.requireContext()
         val appId = context.getString(R.string.google_ads_app_id)
-        // val initConfig = InitializationConfig.Builder(applicationId = appId) #gmaNextGen
-        //     .apply { #gmaNextGen
-        if (Constants.DEBUG && Constants.IS_DEBUG_BUILD) {
-            // setRequestConfiguration(makeAdsRequestConfig(context)) #gmaNextGen
-            MobileAds.setRequestConfiguration(makeAdsRequestConfig(context))
-            disableMediationAdapterInit(context, appId)
-        }
-        //     } #gmaNextGen
-        // } #gmaNextGen
-        // .build() #gmaNextGen
+        val initConfig = InitializationConfig.Builder(applicationId = appId) // #gmaNextGen
+            .apply { // #gmaNextGen
+                if (Constants.DEBUG && Constants.IS_DEBUG_BUILD) {
+                    setRequestConfiguration(makeAdsRequestConfig(context)) // #gmaNextGen
+                    // MobileAds.setRequestConfiguration(makeAdsRequestConfig(context)) // #gmaLegacy
+                    disableMediationAdapterInit(context, appId)
+                }
+            } // #gmaNextGen
+            .build() //  #gmaNextGen
         MobileAds.initialize(
             activity.requireActivity(), // some adapters require activity
-            // initConfig, #gmaNextGen
+            initConfig, // #gmaNextGen
         ) { initializationStatus ->
             this.initialized.set(true)
             this.initializing.set(false)
@@ -212,7 +211,8 @@ class GlobalAdManager(
                     }
                 )
             }
-            MobileAds.setAppMuted(true) // not a media app -> sound off by default
+            MobileAds.setUserMutedApp(true) // not a media app -> sound off by default // #gmaNextGen
+            // MobileAds.setAppMuted(true) // not a media app -> sound off by default // #gmaLegacy
             onInitCompleteListener()
         }
     }

--- a/app-android/src/main/java/org/mtransit/android/ad/appopen/AppOpenAdFullScreenContentCallback.kt
+++ b/app-android/src/main/java/org/mtransit/android/ad/appopen/AppOpenAdFullScreenContentCallback.kt
@@ -1,9 +1,9 @@
 package org.mtransit.android.ad.appopen
 
-// import com.google.android.libraries.ads.mobile.sdk.common.FullScreenContentError #gmaNextGen
-// import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAdEventCallback #gmaNextGen
-import com.google.android.gms.ads.AdError
-import com.google.android.gms.ads.FullScreenContentCallback
+// import com.google.android.gms.ads.AdError // #gmaLegacy
+// import com.google.android.gms.ads.FullScreenContentCallback // #gmaLegacy
+import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAdEventCallback // #gmaNextGen
+import com.google.android.libraries.ads.mobile.sdk.common.FullScreenContentError // #gmaNextGen
 import org.mtransit.android.ad.AdConstants.logAdsD
 import org.mtransit.android.ad.AdManager
 import org.mtransit.android.commons.MTLog
@@ -13,8 +13,8 @@ class AppOpenAdFullScreenContentCallback(
     private val appOpenAdManager: AppOpenAdManager,
     private val crashReporter: CrashReporter,
     private val onShowAdComplete: () -> Unit
-    // ) : AppOpenAdEventCallback, #gmaNextGen
-) : FullScreenContentCallback(),
+) : AppOpenAdEventCallback, // #gmaNextGen
+    // ) : FullScreenContentCallback(), // #gmaLegacy
     MTLog.Loggable {
 
     companion object {
@@ -31,8 +31,8 @@ class AppOpenAdFullScreenContentCallback(
         // TODO ? this.appOpenAdManager.loadAd()
     }
 
-    // override fun onAdFailedToShowFullScreenContent(fullScreenContentError: FullScreenContentError) { #gmaNextGen
-    override fun onAdFailedToShowFullScreenContent(fullScreenContentError: AdError) {
+    override fun onAdFailedToShowFullScreenContent(fullScreenContentError: FullScreenContentError) { // #gmaNextGen
+        // override fun onAdFailedToShowFullScreenContent(fullScreenContentError: AdError) { // #gmaLegacy
         logAdsD(this, "onAdFailedToShowFullScreenContent() > App open ad failed to show fullscreen content.")
         this.appOpenAdManager.appOpenAd = null // clear dismissed ad
         this.appOpenAdManager.isShowingAd = false
@@ -42,8 +42,8 @@ class AppOpenAdFullScreenContentCallback(
             this,
             "Failed to show app open ad! ${fullScreenContentError.code}: " +
                     "'${fullScreenContentError.message}' " +
-                    // "(${fullScreenContentError.mediationAdError})." #gmaNextGen
-                    "(${fullScreenContentError.domain})."
+                    "(${fullScreenContentError.mediationAdError})." // #gmaNextGen
+            // "(${fullScreenContentError.domain})." // #gmaLegacy
         )
     }
 

--- a/app-android/src/main/java/org/mtransit/android/ad/appopen/AppOpenAdManager.kt
+++ b/app-android/src/main/java/org/mtransit/android/ad/appopen/AppOpenAdManager.kt
@@ -3,8 +3,11 @@ package org.mtransit.android.ad.appopen
 import android.content.Context
 import androidx.annotation.MainThread
 import androidx.annotation.StringRes
-import com.google.android.gms.ads.LoadAdError
-import com.google.android.gms.ads.appopen.AppOpenAd
+import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAd // #gmaNextGen
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback // #gmaNextGen
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError // #gmaNextGen
+// import com.google.android.gms.ads.LoadAdError // #gmaLegacy
+// import com.google.android.gms.ads.appopen.AppOpenAd // #gmaLegacy
 import dagger.hilt.android.qualifiers.ApplicationContext
 import org.mtransit.android.R
 import org.mtransit.android.ad.AdConstants
@@ -69,21 +72,26 @@ class AppOpenAdManager @Inject constructor(
             return false
         }
         isLoadingAd.set(true)
-        AppOpenAd.load( // Must be called on the main UI thread
-            appContext,
-            appContext.getString(adUnitStringResId),
+        AppOpenAd.load(
+            // Must be called on the main UI thread
+            // appContext, // #gmaLegacy
+            // appContext.getString(adUnitStringResId), // #gmaLegacy
             AdManager.getAdRequest(
                 adUnitId = appContext.getString(adUnitStringResId)
             ),
-            object : AppOpenAd.AppOpenAdLoadCallback() {
+            object : AdLoadCallback<AppOpenAd> { // #gmaNextGen
+                // object : AppOpenAd.AppOpenAdLoadCallback() { // #gmaLegacy
                 override fun onAdLoaded(ad: AppOpenAd) {
                     appOpenAd = ad
                     isLoadingAd.set(false)
                     loadTimeK = TimeUtilsK.currentInstant()
                 }
 
-                override fun onAdFailedToLoad(loadAdError: LoadAdError) {
-                    logAdsD(LOG_TAG, "App open ad failed to load with error: ${loadAdError.message}")
+                // override fun onAdFailedToLoad(loadAdError: LoadAdError) { // #gmaLegacy
+                override fun onAdFailedToLoad(adError: LoadAdError) {
+                    // val loadAdErrorMessage = loadAdError.message // #gmaLegacy
+                    val loadAdErrorMessage = adError.message // #gmaNextGen
+                    logAdsD(LOG_TAG, "App open ad failed to load with error: $loadAdErrorMessage")
                     isLoadingAd.set(false)
                 }
             },
@@ -103,7 +111,9 @@ class AppOpenAdManager @Inject constructor(
             return // Load an ad.
         }
         isShowingAd = true
-        appOpenAd?.fullScreenContentCallback = AppOpenAdFullScreenContentCallback(this, crashReporter, onShowAdComplete)
+        // appOpenAd?.fullScreenContentCallback = // #gmaLegacy
+        appOpenAd?.adEventCallback = // #gmaNextGen
+            AppOpenAdFullScreenContentCallback(this, crashReporter, onShowAdComplete)
         appOpenAd?.show(activity.requireActivity())
     }
 

--- a/app-android/src/main/java/org/mtransit/android/ad/banner/BannerAdListener.kt
+++ b/app-android/src/main/java/org/mtransit/android/ad/banner/BannerAdListener.kt
@@ -104,11 +104,11 @@ class BannerAdListener(
     override fun onAdRefreshed() { // #gmaNextGen
         super.onAdRefreshed() // #gmaNextGen
         logAdsD(this, "onAdRefreshed()") // #gmaNextGen
-        this.bannerAdManager.setAdBannerLoaded(TimeUtils.currentTimeMillis(), true) // success // #gmaNextGen
         this.activityWR.get()?.let { activity -> // #gmaNextGen
-            this.bannerAdManager.adaptToScreenSize( // #gmaNextGen
-                activity, // #gmaNextGen
-            ) // showing ads if hidden because of no-fill/network error // #gmaNextGen
+            activity.activity?.runOnUiThread {
+                this.bannerAdManager.setAdBannerLoaded(TimeUtils.currentTimeMillis(), true) // success // #gmaNextGen
+                this.bannerAdManager.adaptToScreenSize(activity) // showing ads if hidden because of no-fill/network error // #gmaNextGen
+            }
         } // #gmaNextGen
     } // #gmaNextGen
 
@@ -123,15 +123,13 @@ class BannerAdListener(
         // ad.adEventCallback =
         //     object : BannerAdEventCallback {}
         ad.bannerAdRefreshCallback = this // #gmaNextGen
-        this.bannerAdManager.setAdBannerLoaded(TimeUtils.currentTimeMillis(), true) // success
         this.activityWR.get()?.let { activity ->
             activity.activity?.runOnUiThread {
+                this.bannerAdManager.setAdBannerLoaded(TimeUtils.currentTimeMillis(), true) // success
                 // val adapterClassName = this.adViewWR.get()?.responseInfo?.mediationAdapterClassName // #gmaLegacy
                 val adapterClassName = ad.getResponseInfo().adapterClassName // #gmaNextGen
                 logAdsD(this, "onAdLoaded() > ad loaded from $adapterClassName ")
-                this.bannerAdManager.adaptToScreenSize(
-                    activity,
-                ) // showing ads if hidden because of no-fill/network error
+                this.bannerAdManager.adaptToScreenSize(activity) // showing ads if hidden because of no-fill/network error // #gmaNextGen
             }
         }
     }

--- a/app-android/src/main/java/org/mtransit/android/ad/banner/BannerAdListener.kt
+++ b/app-android/src/main/java/org/mtransit/android/ad/banner/BannerAdListener.kt
@@ -1,13 +1,13 @@
 package org.mtransit.android.ad.banner
 
+// import com.google.android.gms.ads.AdListener // #gmaLegacy
+// import com.google.android.gms.ads.AdRequest // #gmaLegacy
+// import com.google.android.gms.ads.AdView // #gmaLegacy
+// import com.google.android.gms.ads.LoadAdError // #gmaLegacy
 import androidx.annotation.AnyThread
-import com.google.android.gms.ads.AdListener
-import com.google.android.gms.ads.AdRequest
-import com.google.android.gms.ads.AdView
-import com.google.android.gms.ads.LoadAdError
-// import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd // #gmaNextGen
-// import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback // #gmaNextGen
-// import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError // #gmaNextGen
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd // #gmaNextGen
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback // #gmaNextGen
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError // #gmaNextGen
 import org.mtransit.android.ad.AdConstants.logAdsD
 import org.mtransit.android.ad.AdManager
 import org.mtransit.android.ad.IAdScreenActivity
@@ -20,21 +20,21 @@ class BannerAdListener(
     private val bannerAdManager: BannerAdManager,
     private val crashReporter: CrashReporter,
     private val activityWR: WeakReference<IAdScreenActivity>,
-    private val adViewWR: WeakReference<AdView>,
-    // ) : AdLoadCallback<BannerAd>, #gmaNextGen
-) : AdListener(),
+    // private val adViewWR: WeakReference<AdView>, // #gmaLegacy
+) : AdLoadCallback<BannerAd>, // #gmaNextGen
+    // ) : AdListener(), // #gmaLegacy
     MTLog.Loggable {
 
     constructor(
         bannerAdManager: BannerAdManager,
         crashReporter: CrashReporter,
         adScreenActivity: IAdScreenActivity,
-        adView: AdView,
+        // adView: AdView, // #gmaLegacy
     ) : this(
         bannerAdManager = bannerAdManager,
         crashReporter = crashReporter,
         activityWR = WeakReference(adScreenActivity),
-        adViewWR = WeakReference(adView)
+        // adViewWR = WeakReference(adView) // #gmaLegacy
     )
 
     companion object {
@@ -48,37 +48,37 @@ class BannerAdListener(
         super.onAdFailedToLoad(adError)
         logAdsD(this, "onAdFailedToLoad($adError)")
         when (adError.code) {
-            AdRequest.ERROR_CODE_APP_ID_MISSING ->
-                // LoadAdError.ErrorCode.APP_ID_MISSING -> #gmaNextGen
+            // AdRequest.ERROR_CODE_APP_ID_MISSING -> // #gmaLegacy
+            LoadAdError.ErrorCode.APP_ID_MISSING -> // #gmaNextGen
                 this.crashReporter.w(this, "Failed to receive ad! App ID missing: '${adError.code}' ($adError).")
 
-            AdRequest.ERROR_CODE_INTERNAL_ERROR ->
-                // LoadAdError.ErrorCode.INTERNAL_ERROR -> #gmaNextGen
+            // AdRequest.ERROR_CODE_INTERNAL_ERROR -> // #gmaLegacy
+            LoadAdError.ErrorCode.INTERNAL_ERROR -> // #gmaNextGen
                 this.crashReporter.w(this, "Failed to receive ad! Internal error code: '${adError.code}' ($adError).")
 
-            AdRequest.ERROR_CODE_INVALID_REQUEST ->
-                // LoadAdError.ErrorCode.INVALID_REQUEST -> #gmaNextGen
+            // AdRequest.ERROR_CODE_INVALID_REQUEST -> // #gmaLegacy
+            LoadAdError.ErrorCode.INVALID_REQUEST -> // #gmaNextGen
                 this.crashReporter.w(this, "Failed to receive ad! Invalid request error code: '${adError.code}' ($adError).")
 
-            AdRequest.ERROR_CODE_REQUEST_ID_MISMATCH ->
-                // LoadAdError.ErrorCode.REQUEST_ID_MISMATCH -> #gmaNextGen
+            // AdRequest.ERROR_CODE_REQUEST_ID_MISMATCH -> // #gmaLegacy
+            LoadAdError.ErrorCode.REQUEST_ID_MISMATCH -> // #gmaNextGen
                 this.crashReporter.w(this, "Failed to receive ad! Request ID mismatch error code: '${adError.code}' ($adError).")
 
-            AdRequest.ERROR_CODE_NETWORK_ERROR ->
-                // LoadAdError.ErrorCode.NETWORK_ERROR -> #gmaNextGen
+            // AdRequest.ERROR_CODE_NETWORK_ERROR -> // #gmaLegacy
+            LoadAdError.ErrorCode.NETWORK_ERROR -> // #gmaNextGen
                 MTLog.w(this, "Failed to receive ad! Network error code: '${adError.code}' ($adError).")
 
-            AdRequest.ERROR_CODE_MEDIATION_NO_FILL,
-            AdRequest.ERROR_CODE_NO_FILL ->
-                // LoadAdError.ErrorCode.NO_FILL -> #gmaNextGen
+            // AdRequest.ERROR_CODE_MEDIATION_NO_FILL, // #gmaLegacy
+            // AdRequest.ERROR_CODE_NO_FILL -> // #gmaLegacy
+            LoadAdError.ErrorCode.NO_FILL -> // #gmaNextGen
                 MTLog.w(this, "Failed to receive ad! No fill error code: '${adError.code}' ($adError).")
 
-            // LoadAdError.ErrorCode.TIMEOUT, #gmaNextGen
-            // LoadAdError.ErrorCode.CANCELLED, #gmaNextGen
-            // LoadAdError.ErrorCode.NOT_FOUND, #gmaNextGen
-            // LoadAdError.ErrorCode.INVALID_AD_RESPONSE, #gmaNextGen
-            // LoadAdError.ErrorCode.AD_RESPONSE_ALREADY_USED,#gmaNextGen
-            else
+            LoadAdError.ErrorCode.TIMEOUT, // #gmaNextGen
+            LoadAdError.ErrorCode.CANCELLED, // #gmaNextGen
+            LoadAdError.ErrorCode.NOT_FOUND, // #gmaNextGen
+            LoadAdError.ErrorCode.INVALID_AD_RESPONSE, // #gmaNextGen
+            LoadAdError.ErrorCode.AD_RESPONSE_ALREADY_USED, // #gmaNextGen
+                // else // #gmaLegacy
                 -> this.crashReporter.w(this, "Failed to receive ad! Error code: '${adError.code}' ($adError).")
         }
         this.activityWR.get()?.let { activity ->
@@ -95,18 +95,17 @@ class BannerAdListener(
     }
 
     @AnyThread
-    // override fun onAdLoaded(ad: BannerAd) { #gmaNextGen
-    // super.onAdLoaded(ad) #gmaNextGen
-    // logAdsD(this, "onAdLoaded($ad)") #gmaNextGen
-    override fun onAdLoaded() {
-        super.onAdLoaded()
-        logAdsD(this, "onAdLoaded()")
-        // val adapterClassName = ad.getResponseInfo().adapterClassName #gmaNextGen
-        // logAdsD(this, "onAdLoaded() > ad loaded from $adapterClassName ")
+    override fun onAdLoaded(ad: BannerAd) { // #gmaNextGen
+        super.onAdLoaded(ad) // #gmaNextGen
+        logAdsD(this, "onAdLoaded($ad)") // #gmaNextGen
+        // override fun onAdLoaded() { // #gmaLegacy
+        // super.onAdLoaded() // #gmaLegacy
+        // logAdsD(this, "onAdLoaded()") // #gmaLegacy
         this.activityWR.get()?.let { activity ->
             activity.activity?.runOnUiThread {
                 this.bannerAdManager.setAdBannerLoaded(TimeUtils.currentTimeMillis(), true) // success
-                val adapterClassName = this.adViewWR.get()?.responseInfo?.mediationAdapterClassName
+                // val adapterClassName = this.adViewWR.get()?.responseInfo?.mediationAdapterClassName // #gmaLegacy
+                val adapterClassName = ad.getResponseInfo().adapterClassName // #gmaNextGen
                 logAdsD(this, "onAdLoaded() > ad loaded from $adapterClassName ")
                 this.bannerAdManager.adaptToScreenSize(
                     activity,

--- a/app-android/src/main/java/org/mtransit/android/ad/banner/BannerAdListener.kt
+++ b/app-android/src/main/java/org/mtransit/android/ad/banner/BannerAdListener.kt
@@ -6,6 +6,7 @@ package org.mtransit.android.ad.banner
 // import com.google.android.gms.ads.LoadAdError // #gmaLegacy
 import androidx.annotation.AnyThread
 import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd // #gmaNextGen
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRefreshCallback // #gmaNextGen
 import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback // #gmaNextGen
 import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError // #gmaNextGen
 import org.mtransit.android.ad.AdConstants.logAdsD
@@ -21,7 +22,7 @@ class BannerAdListener(
     private val crashReporter: CrashReporter,
     private val activityWR: WeakReference<IAdScreenActivity>,
     // private val adViewWR: WeakReference<AdView>, // #gmaLegacy
-) : AdLoadCallback<BannerAd>, // #gmaNextGen
+) : AdLoadCallback<BannerAd>, BannerAdRefreshCallback, // #gmaNextGen
     // ) : AdListener(), // #gmaLegacy
     MTLog.Loggable {
 
@@ -94,6 +95,23 @@ class BannerAdListener(
         }
     }
 
+    override fun onAdFailedToRefresh(adError: LoadAdError) { // #gmaNextGen
+        super.onAdFailedToRefresh(adError) // #gmaNextGen
+        logAdsD(this, "onAdFailedToRefresh($adError)") // #gmaNextGen
+        onAdFailedToLoad(adError) // #gmaNextGen
+    } // #gmaNextGen
+
+    override fun onAdRefreshed() { // #gmaNextGen
+        super.onAdRefreshed() // #gmaNextGen
+        logAdsD(this, "onAdRefreshed()") // #gmaNextGen
+        this.bannerAdManager.setAdBannerLoaded(TimeUtils.currentTimeMillis(), true) // success // #gmaNextGen
+        this.activityWR.get()?.let { activity -> // #gmaNextGen
+            this.bannerAdManager.adaptToScreenSize( // #gmaNextGen
+                activity, // #gmaNextGen
+            ) // showing ads if hidden because of no-fill/network error // #gmaNextGen
+        } // #gmaNextGen
+    } // #gmaNextGen
+
     @AnyThread
     override fun onAdLoaded(ad: BannerAd) { // #gmaNextGen
         super.onAdLoaded(ad) // #gmaNextGen
@@ -101,9 +119,13 @@ class BannerAdListener(
         // override fun onAdLoaded() { // #gmaLegacy
         // super.onAdLoaded() // #gmaLegacy
         // logAdsD(this, "onAdLoaded()") // #gmaLegacy
+        // // Called when an ad has loaded.
+        // ad.adEventCallback =
+        //     object : BannerAdEventCallback {}
+        ad.bannerAdRefreshCallback = this // #gmaNextGen
+        this.bannerAdManager.setAdBannerLoaded(TimeUtils.currentTimeMillis(), true) // success
         this.activityWR.get()?.let { activity ->
             activity.activity?.runOnUiThread {
-                this.bannerAdManager.setAdBannerLoaded(TimeUtils.currentTimeMillis(), true) // success
                 // val adapterClassName = this.adViewWR.get()?.responseInfo?.mediationAdapterClassName // #gmaLegacy
                 val adapterClassName = ad.getResponseInfo().adapterClassName // #gmaNextGen
                 logAdsD(this, "onAdLoaded() > ad loaded from $adapterClassName ")

--- a/app-android/src/main/java/org/mtransit/android/ad/banner/BannerAdManager.kt
+++ b/app-android/src/main/java/org/mtransit/android/ad/banner/BannerAdManager.kt
@@ -6,10 +6,10 @@ import android.os.Build
 import android.view.ViewGroup
 import androidx.annotation.AnyThread
 import androidx.annotation.MainThread
-import com.google.android.gms.ads.AdSize
-import com.google.android.gms.ads.AdView
-// import com.google.android.libraries.ads.mobile.sdk.banner.AdSize #gmaNextGen
-// import com.google.android.libraries.ads.mobile.sdk.banner.AdView #gmaNextGen
+// import com.google.android.gms.ads.AdSize // #gmaLegacy
+// import com.google.android.gms.ads.AdView // #gmaLegacy
+import com.google.android.libraries.ads.mobile.sdk.banner.AdSize // #gmaNextGen
+import com.google.android.libraries.ads.mobile.sdk.banner.AdView // #gmaNextGen
 import org.mtransit.android.R
 import org.mtransit.android.ad.AdConstants
 import org.mtransit.android.ad.AdConstants.logAdsD
@@ -181,23 +181,23 @@ class BannerAdManager @Inject constructor(
     }
 
     @MainThread
-    // fun resumeAd(@Suppress("unused") activity: IAdScreenActivity) { #gmaNextGen
-    // DO NOTHING #gmaNextGen
-    fun resumeAd(activity: IAdScreenActivity) {
-        if (!AdConstants.AD_ENABLED) return
-        getAdLayout(activity)?.let { adLayout ->
-            getAdView(adLayout)?.resume()
-        }
+    fun resumeAd(@Suppress("unused") activity: IAdScreenActivity) { // #gmaNextGen
+        // DO NOTHING // #gmaNextGen
+        // fun resumeAd(activity: IAdScreenActivity) { // #gmaLegacy
+        //     if (!AdConstants.AD_ENABLED) return // #gmaLegacy
+        //     getAdLayout(activity)?.let { adLayout -> // #gmaLegacy
+        //         getAdView(adLayout)?.resume() // #gmaLegacy
+        //     } // #gmaLegacy
     }
 
     @MainThread
-    // fun pauseAd(@Suppress("unused") activity: IAdScreenActivity) { #gmaNextGen
-    // DO NOTHING #gmaNextGen
-    fun pauseAd(activity: IAdScreenActivity) {
-        if (!AdConstants.AD_ENABLED) return
-        getAdLayout(activity)?.let { adLayout ->
-            getAdView(adLayout)?.pause()
-        }
+    fun pauseAd(@Suppress("unused") activity: IAdScreenActivity) { // #gmaNextGen
+        // DO NOTHING // #gmaNextGen
+        // fun pauseAd(activity: IAdScreenActivity) { // #gmaLegacy
+        //     if (!AdConstants.AD_ENABLED) return // #gmaLegacy
+        //     getAdLayout(activity)?.let { adLayout -> // #gmaLegacy
+        //         getAdView(adLayout)?.pause() // #gmaLegacy
+        //     } // #gmaLegacy
     }
 
     fun getAdLayout(activity: IAdScreenActivity): ViewGroup? =

--- a/app-android/src/main/java/org/mtransit/android/ad/banner/SetupBannerAdTask.kt
+++ b/app-android/src/main/java/org/mtransit/android/ad/banner/SetupBannerAdTask.kt
@@ -5,8 +5,8 @@ import androidx.annotation.MainThread
 import androidx.annotation.StringRes
 import androidx.annotation.WorkerThread
 import androidx.core.view.isVisible
-import com.google.android.gms.ads.AdView
-// import com.google.android.libraries.ads.mobile.sdk.banner.AdView #gmaNextGen
+// import com.google.android.gms.ads.AdView // #gmaLegacy
+import com.google.android.libraries.ads.mobile.sdk.banner.AdView // #gmaNextGen
 import org.mtransit.android.R
 import org.mtransit.android.ad.AdConstants
 import org.mtransit.android.ad.AdManager
@@ -57,13 +57,13 @@ class SetupBannerAdTask(
                 val adView = this.bannerAdManager.getAdView(adLayout)
                     ?: makeNewAdView(activity, adLayout)
                 adView.loadAd(
-                    // adRequest =
-                    AdManager.getBannerAdRequest(
-                        adUnitId = activity.requireActivity().getString(adUnitStringResId),
-                        adSize = bannerAdManager.getAdSize(activity),
-                        collapsible = UIFeatureFlags.F_ADS_BANNER_COLLAPSIBLE
-                    ),
-                    // adLoadCallback = BannerAdListener(bannerAdManager, crashReporter, activity) #gmaNextGen
+                    adRequest = // #gmaNextGen
+                        AdManager.getBannerAdRequest(
+                            adUnitId = activity.requireActivity().getString(adUnitStringResId),
+                            adSize = bannerAdManager.getAdSize(activity),
+                            collapsible = UIFeatureFlags.F_ADS_BANNER_COLLAPSIBLE
+                        ),
+                    adLoadCallback = BannerAdListener(bannerAdManager, crashReporter, activity) // #gmaNextGen
                 )
             }
         } else if (!adsAllowed) { // hide ads
@@ -86,12 +86,12 @@ class SetupBannerAdTask(
             )
             isVisible = false
             id = R.id.ad
-            adUnitId = activity.requireContext().getString(adUnitStringResId)
+            // adUnitId = activity.requireContext().getString(adUnitStringResId) // #gmaLegacy
         }.also {
             adLayout.removeAllViews()
             adLayout.addView(it)
-        }.apply {
-            setAdSize(bannerAdManager.getAdSize(activity)) // ad size can only be set once
-            adListener = BannerAdListener(bannerAdManager, crashReporter, activity, adView = this)
+            // }.apply { // #gmaLegacy
+            // setAdSize(bannerAdManager.getAdSize(activity)) // ad size can only be set once // #gmaLegacy
+            // adListener = BannerAdListener(bannerAdManager, crashReporter, activity, adView = this) // #gmaLegacy
         }
 }

--- a/app-android/src/main/java/org/mtransit/android/ad/inlinebanner/InlineBannerAdListener.kt
+++ b/app-android/src/main/java/org/mtransit/android/ad/inlinebanner/InlineBannerAdListener.kt
@@ -110,6 +110,7 @@ class InlineBannerAdListener(
         super.onAdLoaded(ad) // #gmaNextGen
         // override fun onAdLoaded() { // #gmaLegacy
         // super.onAdLoaded() // #gmaLegacy
+        ad.bannerAdRefreshCallback = this // #gmaNextGen
         this.fragmentWR.get()?.let { fragment ->
             fragment.getActivity()?.runOnUiThread {
                 // val adapterClassName = this.adViewWR.get()?.responseInfo?.mediationAdapterClassName // #gmaLegacy

--- a/app-android/src/main/java/org/mtransit/android/ad/inlinebanner/InlineBannerAdListener.kt
+++ b/app-android/src/main/java/org/mtransit/android/ad/inlinebanner/InlineBannerAdListener.kt
@@ -1,13 +1,13 @@
 package org.mtransit.android.ad.inlinebanner
 
 import androidx.annotation.AnyThread
-import com.google.android.gms.ads.AdListener
-import com.google.android.gms.ads.AdRequest
-import com.google.android.gms.ads.AdView
-import com.google.android.gms.ads.LoadAdError
-// import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd #gmaNextGen
-// import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback #gmaNextGen
-// import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError #gmaNextGen
+// import com.google.android.gms.ads.AdListener // #gmaLegacy
+// import com.google.android.gms.ads.AdRequest // #gmaLegacy
+// import com.google.android.gms.ads.AdView // #gmaLegacy
+// import com.google.android.gms.ads.LoadAdError // #gmaLegacy
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd // #gmaNextGen
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback // #gmaNextGen
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError // #gmaNextGen
 import org.mtransit.android.ad.AdConstants.logAdsD
 import org.mtransit.android.ad.AdManager
 import org.mtransit.android.commons.MTLog
@@ -19,21 +19,21 @@ class InlineBannerAdListener(
     private val inlineBannerAdManager: InlineBannerAdManager,
     private val crashReporter: CrashReporter,
     private val fragmentWR: WeakReference<IFragment>,
-    private val adViewWR: WeakReference<AdView>,
-    // ) : AdLoadCallback<BannerAd>, #gmaNextGen
-) : AdListener(),
+    // private val adViewWR: WeakReference<AdView>, // #gmaLegacy
+) : AdLoadCallback<BannerAd>, // #gmaNextGen
+    // ) : AdListener(), // #gmaLegacy
     MTLog.Loggable {
 
     constructor(
         inlineBannerAdManager: InlineBannerAdManager,
         crashReporter: CrashReporter,
         fragment: IFragment,
-        adView: AdView,
+        // adView: AdView, // #gmaLegacy
     ) : this(
         inlineBannerAdManager = inlineBannerAdManager,
         crashReporter = crashReporter,
         fragmentWR = WeakReference(fragment),
-        adViewWR = WeakReference(adView)
+        // adViewWR = WeakReference(adView) // #gmaLegacy
     )
 
     companion object {
@@ -46,37 +46,37 @@ class InlineBannerAdListener(
     override fun onAdFailedToLoad(adError: LoadAdError) {
         super.onAdFailedToLoad(adError)
         when (adError.code) {
-            AdRequest.ERROR_CODE_APP_ID_MISSING ->
-                // LoadAdError.ErrorCode.APP_ID_MISSING -> #gmaNextGen
+            // AdRequest.ERROR_CODE_APP_ID_MISSING -> // #gmaLegacy
+            LoadAdError.ErrorCode.APP_ID_MISSING -> // #gmaNextGen
                 this.crashReporter.w(this, "Failed to receive ad! App ID missing: '${adError.code}' ($adError).")
 
-            AdRequest.ERROR_CODE_INTERNAL_ERROR ->
-                // LoadAdError.ErrorCode.INTERNAL_ERROR -> #gmaNextGen
+            // AdRequest.ERROR_CODE_INTERNAL_ERROR -> // #gmaLegacy
+            LoadAdError.ErrorCode.INTERNAL_ERROR -> // #gmaNextGen
                 this.crashReporter.w(this, "Failed to receive ad! Internal error code: '${adError.code}' ($adError).")
 
-            AdRequest.ERROR_CODE_INVALID_REQUEST ->
-                // LoadAdError.ErrorCode.INVALID_REQUEST -> #gmaNextGen
+            // AdRequest.ERROR_CODE_INVALID_REQUEST -> // #gmaLegacy
+            LoadAdError.ErrorCode.INVALID_REQUEST -> // #gmaNextGen
                 this.crashReporter.w(this, "Failed to receive ad! Invalid request error code: '${adError.code}' ($adError).")
 
-            AdRequest.ERROR_CODE_REQUEST_ID_MISMATCH ->
-                // LoadAdError.ErrorCode.REQUEST_ID_MISMATCH -> #gmaNextGen
+            // AdRequest.ERROR_CODE_REQUEST_ID_MISMATCH -> // #gmaLegacy
+            LoadAdError.ErrorCode.REQUEST_ID_MISMATCH -> // #gmaNextGen
                 this.crashReporter.w(this, "Failed to receive ad! Request ID mismatch error code: '${adError.code}' ($adError).")
 
-            AdRequest.ERROR_CODE_NETWORK_ERROR ->
-                // LoadAdError.ErrorCode.NETWORK_ERROR -> #gmaNextGen
+            // AdRequest.ERROR_CODE_NETWORK_ERROR -> // #gmaLegacy
+            LoadAdError.ErrorCode.NETWORK_ERROR -> // #gmaNextGen
                 MTLog.w(this, "Failed to receive ad! Network error code: '${adError.code}' ($adError).")
 
-            AdRequest.ERROR_CODE_MEDIATION_NO_FILL,
-            AdRequest.ERROR_CODE_NO_FILL ->
-                // LoadAdError.ErrorCode.NO_FILL -> #gmaNextGen
+            // AdRequest.ERROR_CODE_MEDIATION_NO_FILL, // #gmaLegacy
+            // AdRequest.ERROR_CODE_NO_FILL -> // #gmaLegacy
+            LoadAdError.ErrorCode.NO_FILL -> // #gmaNextGen
                 MTLog.w(this, "Failed to receive ad! No fill error code: '${adError.code}' ($adError).")
 
-            // LoadAdError.ErrorCode.TIMEOUT, #gmaNextGen
-            // LoadAdError.ErrorCode.CANCELLED, #gmaNextGen
-            // LoadAdError.ErrorCode.NOT_FOUND, #gmaNextGen
-            // LoadAdError.ErrorCode.INVALID_AD_RESPONSE, #gmaNextGen
-            // LoadAdError.ErrorCode.AD_RESPONSE_ALREADY_USED,#gmaNextGen
-            else
+            LoadAdError.ErrorCode.TIMEOUT, // #gmaNextGen
+            LoadAdError.ErrorCode.CANCELLED, // #gmaNextGen
+            LoadAdError.ErrorCode.NOT_FOUND, // #gmaNextGen
+            LoadAdError.ErrorCode.INVALID_AD_RESPONSE, // #gmaNextGen
+            LoadAdError.ErrorCode.AD_RESPONSE_ALREADY_USED, // #gmaNextGen
+                // else // #gmaLegacy
                 -> this.crashReporter.w(this, "Failed to receive ad! Error code: '${adError.code}' ($adError).")
         }
         this.fragmentWR.get()?.let { fragment ->
@@ -88,15 +88,14 @@ class InlineBannerAdListener(
     }
 
     @AnyThread
-    // override fun onAdLoaded(ad: BannerAd) { #gmaNextGen
-    // super.onAdLoaded(ad) #gmaNextGen
-    override fun onAdLoaded() {
-        super.onAdLoaded()
-        // val adapterClassName = ad.getResponseInfo().adapterClassName #gmaNextGen
-        // logAdsD(this, "onAdLoaded() > ad loaded from $adapterClassName") #gmaNextGen
+    override fun onAdLoaded(ad: BannerAd) { // #gmaNextGen
+        super.onAdLoaded(ad) // #gmaNextGen
+        // override fun onAdLoaded() { // #gmaLegacy
+        // super.onAdLoaded() // #gmaLegacy
         this.fragmentWR.get()?.let { fragment ->
             fragment.getActivity()?.runOnUiThread {
-                val adapterClassName = this.adViewWR.get()?.responseInfo?.mediationAdapterClassName
+                // val adapterClassName = this.adViewWR.get()?.responseInfo?.mediationAdapterClassName // #gmaLegacy
+                val adapterClassName = ad.getResponseInfo().adapterClassName // #gmaNextGen
                 logAdsD(this, "onAdLoaded() > ad loaded from $adapterClassName")
                 this.inlineBannerAdManager.setAdBannerLoaded(fragment, true)
                 this.inlineBannerAdManager.adaptToScreenSize(

--- a/app-android/src/main/java/org/mtransit/android/ad/inlinebanner/InlineBannerAdListener.kt
+++ b/app-android/src/main/java/org/mtransit/android/ad/inlinebanner/InlineBannerAdListener.kt
@@ -6,6 +6,7 @@ import androidx.annotation.AnyThread
 // import com.google.android.gms.ads.AdView // #gmaLegacy
 // import com.google.android.gms.ads.LoadAdError // #gmaLegacy
 import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd // #gmaNextGen
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRefreshCallback // #gmaNextGen
 import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback // #gmaNextGen
 import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError // #gmaNextGen
 import org.mtransit.android.ad.AdConstants.logAdsD
@@ -20,7 +21,7 @@ class InlineBannerAdListener(
     private val crashReporter: CrashReporter,
     private val fragmentWR: WeakReference<IFragment>,
     // private val adViewWR: WeakReference<AdView>, // #gmaLegacy
-) : AdLoadCallback<BannerAd>, // #gmaNextGen
+) : AdLoadCallback<BannerAd>, BannerAdRefreshCallback, // #gmaNextGen
     // ) : AdListener(), // #gmaLegacy
     MTLog.Loggable {
 
@@ -86,6 +87,23 @@ class InlineBannerAdListener(
             }
         }
     }
+
+    override fun onAdFailedToRefresh(adError: LoadAdError) { // #gmaNextGen
+        super.onAdFailedToRefresh(adError) // #gmaNextGen
+        logAdsD(this, "onAdFailedToRefresh($adError)") // #gmaNextGen
+        onAdFailedToLoad(adError) // #gmaNextGen
+    } // #gmaNextGen
+
+    override fun onAdRefreshed() { // #gmaNextGen
+        super.onAdRefreshed() // #gmaNextGen
+        logAdsD(this, "onAdRefreshed()") // #gmaNextGen
+        this.fragmentWR.get()?.let { fragment -> // #gmaNextGen
+            this.inlineBannerAdManager.setAdBannerLoaded(fragment, true) // #gmaNextGen
+            this.inlineBannerAdManager.adaptToScreenSize( // #gmaNextGen
+                fragment, // #gmaNextGen
+            ) // showing ads if hidden because of no-fill/network error // #gmaNextGen
+        } // #gmaNextGen
+    } // #gmaNextGen
 
     @AnyThread
     override fun onAdLoaded(ad: BannerAd) { // #gmaNextGen

--- a/app-android/src/main/java/org/mtransit/android/ad/inlinebanner/InlineBannerAdManager.kt
+++ b/app-android/src/main/java/org/mtransit/android/ad/inlinebanner/InlineBannerAdManager.kt
@@ -3,10 +3,10 @@ package org.mtransit.android.ad.inlinebanner
 import android.os.Build
 import android.view.ViewGroup
 import androidx.annotation.MainThread
-import com.google.android.gms.ads.AdSize
-import com.google.android.gms.ads.AdView
-// import com.google.android.libraries.ads.mobile.sdk.banner.AdSize #gmaNextGen
-// import com.google.android.libraries.ads.mobile.sdk.banner.AdView #gmaNextGen
+// import com.google.android.gms.ads.AdSize // #gmaLegacy
+// import com.google.android.gms.ads.AdView // #gmaLegacy
+import com.google.android.libraries.ads.mobile.sdk.banner.AdSize // #gmaNextGen
+import com.google.android.libraries.ads.mobile.sdk.banner.AdView // #gmaNextGen
 import org.mtransit.android.R
 import org.mtransit.android.ad.AdConstants
 import org.mtransit.android.ad.AdConstants.logAdsD
@@ -121,13 +121,13 @@ class InlineBannerAdManager @Inject constructor(
     }
 
     @MainThread
-    // fun resumeAd(@Suppress("unused") viewFinder: IViewFinder) { #gmaNextGen
-    // DO NOTHING #gmaNextGen
-    fun resumeAd(viewFinder: IViewFinder) {
-        if (!AdConstants.AD_ENABLED) return
-        getAdLayout(viewFinder)?.let { adLayout ->
-            getAdView(adLayout)?.resume()
-        }
+    fun resumeAd(@Suppress("unused") viewFinder: IViewFinder) { // #gmaNextGen
+        // DO NOTHING // #gmaNextGen
+        // fun resumeAd(viewFinder: IViewFinder) { // #gmaLegacy
+        //     if (!AdConstants.AD_ENABLED) return // #gmaLegacy
+        //     getAdLayout(viewFinder)?.let { adLayout -> // #gmaLegacy
+        //         getAdView(adLayout)?.resume() // #gmaLegacy
+        //     } // #gmaLegacy
     }
 
     fun adaptToScreenSize(fragment: IFragment) {
@@ -147,13 +147,13 @@ class InlineBannerAdManager @Inject constructor(
     }
 
     @MainThread
-    // fun pauseAd(@Suppress("unused") viewFinder: IViewFinder) { #gmaNextGen
-    // DO NOTHING #gmaNextGen
-    fun pauseAd(viewFinder: IViewFinder) {
-        if (!AdConstants.AD_ENABLED) return
-        getAdLayout(viewFinder)?.let { adLayout ->
-            getAdView(adLayout)?.pause()
-        }
+    fun pauseAd(@Suppress("unused") viewFinder: IViewFinder) { // #gmaNextGen
+        // DO NOTHING // #gmaNextGen
+        // fun pauseAd(viewFinder: IViewFinder) { // #gmaLegacy
+        //     if (!AdConstants.AD_ENABLED) return // #gmaLegacy
+        //     getAdLayout(viewFinder)?.let { adLayout -> // #gmaLegacy
+        //         getAdView(adLayout)?.pause() // #gmaLegacy
+        //     } // #gmaLegacy
     }
 
     private fun showBannerAd(viewFinder: IViewFinder) {

--- a/app-android/src/main/java/org/mtransit/android/ad/inlinebanner/SetupInlineBannerAdTask.kt
+++ b/app-android/src/main/java/org/mtransit/android/ad/inlinebanner/SetupInlineBannerAdTask.kt
@@ -5,8 +5,8 @@ import androidx.annotation.MainThread
 import androidx.annotation.StringRes
 import androidx.annotation.WorkerThread
 import androidx.core.view.isVisible
-import com.google.android.gms.ads.AdView
-// import com.google.android.libraries.ads.mobile.sdk.banner.AdView #gmaNextGen
+// import com.google.android.gms.ads.AdView // #gmaLegacy
+import com.google.android.libraries.ads.mobile.sdk.banner.AdView // #gmaNextGen
 import org.mtransit.android.R
 import org.mtransit.android.ad.AdConstants
 import org.mtransit.android.ad.AdManager
@@ -56,12 +56,12 @@ class SetupInlineBannerAdTask(
                 val adView = this.inlineBannerAdManager.getAdView(adLayout)
                     ?: makeNewAdView(fragment, adLayout)
                 adView.loadAd(
-                    // adRequest =
-                    AdManager.getBannerAdRequest(
-                        adUnitId = fragment.requireActivity().getString(adUnitStringResId),
-                        adSize = inlineBannerAdManager.getAdSize(fragment),
-                    ),
-                    // adLoadCallback = InlineBannerAdListener(inlineBannerAdManager, crashReporter, fragment) #gmaNextGen
+                    adRequest = // #gmaNextGen
+                        AdManager.getBannerAdRequest(
+                            adUnitId = fragment.requireActivity().getString(adUnitStringResId),
+                            adSize = inlineBannerAdManager.getAdSize(fragment),
+                        ),
+                    adLoadCallback = InlineBannerAdListener(inlineBannerAdManager, crashReporter, fragment) // #gmaNextGen
                 )
             }
         } else { // hide ads
@@ -80,12 +80,12 @@ class SetupInlineBannerAdTask(
             )
             isVisible = false
             id = R.id.inline_banner_ad
-            adUnitId = fragment.requireContext().getString(adUnitStringResId)
+            // adUnitId = fragment.requireContext().getString(adUnitStringResId) // #gmaLegacy
         }.also {
             adLayout.removeAllViews()
             adLayout.addView(it)
-        }.apply {
-            setAdSize(inlineBannerAdManager.getAdSize(fragment)) // ad size can only be set once
-            adListener = InlineBannerAdListener(inlineBannerAdManager, crashReporter, fragment, adView = this)
+            // }.apply { // #gmaLegacy
+            //     setAdSize(inlineBannerAdManager.getAdSize(fragment)) // ad size can only be set once // #gmaLegacy
+            //     adListener = InlineBannerAdListener(inlineBannerAdManager, crashReporter, fragment, adView = this) // #gmaLegacy
         }
 }

--- a/app-android/src/main/java/org/mtransit/android/ad/rewarded/RewardItemExt.kt
+++ b/app-android/src/main/java/org/mtransit/android/ad/rewarded/RewardItemExt.kt
@@ -1,6 +1,7 @@
 package org.mtransit.android.ad.rewarded
 
-import com.google.android.gms.ads.rewarded.RewardItem
+// import com.google.android.gms.ads.rewarded.RewardItem // #gmaLegacy
+import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardItem // #gmaNextGen
 
 fun RewardItem.toStringPlus() = buildString {
     append("RewardItem{")

--- a/app-android/src/main/java/org/mtransit/android/ad/rewarded/RewardedAdFullScreenContentCallback.kt
+++ b/app-android/src/main/java/org/mtransit/android/ad/rewarded/RewardedAdFullScreenContentCallback.kt
@@ -1,13 +1,13 @@
 package org.mtransit.android.ad.rewarded
 
 
+// import com.google.android.gms.ads.AdError // #gmaLegacy
+// import com.google.android.gms.ads.FullScreenContentCallback // #gmaLegacy
 import androidx.lifecycle.lifecycleScope
-import com.google.android.gms.ads.AdError
-import com.google.android.gms.ads.FullScreenContentCallback
+import com.google.android.libraries.ads.mobile.sdk.common.FullScreenContentError
+import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAdEventCallback
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-// import com.google.android.libraries.ads.mobile.sdk.common.FullScreenContentError #gmaNextGen
-// import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAdEventCallback #gmaNextGen
 import org.mtransit.android.ad.AdConstants.logAdsD
 import org.mtransit.android.ad.AdManager
 import org.mtransit.android.commons.MTLog
@@ -19,8 +19,8 @@ class RewardedAdFullScreenContentCallback(
     private val rewardedAdManager: RewardedAdManager,
     private val crashReporter: CrashReporter,
     private val activityWR: WeakReference<IActivity>,
-    // ) : RewardedAdEventCallback, #gmaNextGen
-) : FullScreenContentCallback(),
+) : RewardedAdEventCallback, // #gmaNextGen
+    // ) : FullScreenContentCallback(), // #gmaLegacy
     MTLog.Loggable {
 
     constructor(
@@ -50,15 +50,15 @@ class RewardedAdFullScreenContentCallback(
         }
     }
 
-    // override fun onAdFailedToShowFullScreenContent(fullScreenContentError: FullScreenContentError) { #gmaNextGen
-    override fun onAdFailedToShowFullScreenContent(fullScreenContentError: AdError) {
+    override fun onAdFailedToShowFullScreenContent(fullScreenContentError: FullScreenContentError) { // #gmaNextGen
+        // override fun onAdFailedToShowFullScreenContent(fullScreenContentError: AdError) { // #gmaLegacy
         super.onAdFailedToShowFullScreenContent(fullScreenContentError)
         this.crashReporter.w(
             this,
             "Failed to show rewarded ad! ${fullScreenContentError.code}: " +
                     "'${fullScreenContentError.message}' " +
-                    // "(${fullScreenContentError.mediationAdError})." #gmaNextGen
-                    "(${fullScreenContentError.domain})."
+                    "(${fullScreenContentError.mediationAdError})." // #gmaNextGen
+            // "(${fullScreenContentError.domain})." // #gmaLegacy
         )
     }
 

--- a/app-android/src/main/java/org/mtransit/android/ad/rewarded/RewardedAdLoadCallback.kt
+++ b/app-android/src/main/java/org/mtransit/android/ad/rewarded/RewardedAdLoadCallback.kt
@@ -1,24 +1,25 @@
 package org.mtransit.android.ad.rewarded
 
 import androidx.annotation.AnyThread
-import com.google.android.gms.ads.AdRequest
-import com.google.android.gms.ads.LoadAdError
-import com.google.android.gms.ads.rewarded.RewardedAd
-// import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback #gmaNextGen
-// import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError #gmaNextGen
-// import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAd #gmaNextGen
+// import com.google.android.gms.ads.AdRequest // #gmaLegacy
+// import com.google.android.gms.ads.LoadAdError // #gmaLegacy
+// import com.google.android.gms.ads.rewarded.RewardedAd // #gmaLegacy
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback // #gmaNextGen
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError // #gmaNextGen
+import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAd // #gmaNextGen
 import org.mtransit.android.ad.AdConstants.logAdsD
 import org.mtransit.android.ad.AdManager
 import org.mtransit.android.commons.MTLog
 import org.mtransit.android.dev.CrashReporter
-import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback as GRewardedAdLoadCallback
+
+// import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback as GRewardedAdLoadCallback  // #gmaLegacy
 
 class RewardedAdLoadCallback(
     private val rewardedAdManager: RewardedAdManager,
     private val crashReporter: CrashReporter,
     private val activityHashCode: Int,
-    // ) : AdLoadCallback<RewardedAd>, #gmaNextGen
-) : GRewardedAdLoadCallback(),
+) : AdLoadCallback<RewardedAd>, // #gmaNextGen
+    // ) : GRewardedAdLoadCallback(), // #gmaLegacy
     MTLog.Loggable {
 
     companion object {
@@ -30,9 +31,11 @@ class RewardedAdLoadCallback(
     @AnyThread
     override fun onAdLoaded(ad: RewardedAd) {
         super.onAdLoaded(ad)
-        // val adapterClassName = ad.getResponseInfo().adapterClassName #gmaNextGen
-        val adapterClassName = ad.responseInfo.mediationAdapterClassName
-        logAdsD(this, "onAdLoaded() > Rewarded ad '${ad.rewardItem.toStringPlus()}' loaded from '$adapterClassName'.")
+        val adapterClassName = ad.getResponseInfo().adapterClassName // #gmaNextGen
+        // val adapterClassName = ad.responseInfo.mediationAdapterClassName // #gmaLegacy
+        // val adRewardedItem = ad.rewardItem // #gmaLegacy
+        val adRewardedItem = ad.getRewardItem() // #gmaNextGen
+        logAdsD(this, "onAdLoaded() > Rewarded ad '${adRewardedItem.toStringPlus()}' loaded from '$adapterClassName'.")
         this.rewardedAdManager.onRewardedAdLoadingComplete(ad, activityHashCode)
     }
 
@@ -41,37 +44,37 @@ class RewardedAdLoadCallback(
         super.onAdFailedToLoad(adError)
         this.rewardedAdManager.onRewardedAdLoadingComplete(null, activityHashCode)
         when (adError.code) {
-            AdRequest.ERROR_CODE_APP_ID_MISSING ->
-                // LoadAdError.ErrorCode.APP_ID_MISSING -> #gmaNextGen
+            // AdRequest.ERROR_CODE_APP_ID_MISSING -> // #gmaLegacy
+            LoadAdError.ErrorCode.APP_ID_MISSING -> // #gmaNextGen
                 this.crashReporter.w(this, "Failed to receive rewarded ad! App ID missing: '${adError.code}' ($adError).")
 
-            AdRequest.ERROR_CODE_INTERNAL_ERROR ->
-                // LoadAdError.ErrorCode.INTERNAL_ERROR -> #gmaNextGen
+            // AdRequest.ERROR_CODE_INTERNAL_ERROR -> // #gmaLegacy
+            LoadAdError.ErrorCode.INTERNAL_ERROR -> // #gmaNextGen
                 this.crashReporter.w(this, "Failed to receive rewarded ad! Internal error code: '${adError.code}' ($adError).")
 
-            AdRequest.ERROR_CODE_INVALID_REQUEST ->
-                // LoadAdError.ErrorCode.INVALID_REQUEST -> #gmaNextGen
+            // AdRequest.ERROR_CODE_INVALID_REQUEST -> // #gmaLegacy
+            LoadAdError.ErrorCode.INVALID_REQUEST -> // #gmaNextGen
                 this.crashReporter.w(this, "Failed to receive rewarded ad! Invalid request error code: '${adError.code}' ($adError).")
 
-            AdRequest.ERROR_CODE_REQUEST_ID_MISMATCH ->
-                // LoadAdError.ErrorCode.REQUEST_ID_MISMATCH -> #gmaNextGen
+            // AdRequest.ERROR_CODE_REQUEST_ID_MISMATCH -> // #gmaLegacy
+            LoadAdError.ErrorCode.REQUEST_ID_MISMATCH -> // #gmaNextGen
                 this.crashReporter.w(this, "Failed to receive rewarded ad! Request ID mismatch error code: '${adError.code}' ($adError).")
 
-            AdRequest.ERROR_CODE_NETWORK_ERROR ->
-                // LoadAdError.ErrorCode.NETWORK_ERROR -> #gmaNextGen
+            // AdRequest.ERROR_CODE_NETWORK_ERROR -> // #gmaLegacy
+            LoadAdError.ErrorCode.NETWORK_ERROR -> // #gmaNextGen
                 MTLog.w(this, "Failed to receive rewarded ad! Network error code: '${adError.code}' ($adError).")
 
-            AdRequest.ERROR_CODE_MEDIATION_NO_FILL,
-            AdRequest.ERROR_CODE_NO_FILL ->
-                // LoadAdError.ErrorCode.NO_FILL -> #gmaNextGen
+            // AdRequest.ERROR_CODE_MEDIATION_NO_FILL, // #gmaLegacy
+            // AdRequest.ERROR_CODE_NO_FILL -> // #gmaLegacy
+            LoadAdError.ErrorCode.NO_FILL -> // #gmaNextGen
                 this.crashReporter.w(this, "Failed to receive rewarded ad! No fill error code: '${adError.code}' ($adError).")
 
-            // LoadAdError.ErrorCode.TIMEOUT, #gmaNextGen
-            // LoadAdError.ErrorCode.CANCELLED, #gmaNextGen
-            // LoadAdError.ErrorCode.NOT_FOUND, #gmaNextGen
-            // LoadAdError.ErrorCode.INVALID_AD_RESPONSE, #gmaNextGen
-            // LoadAdError.ErrorCode.AD_RESPONSE_ALREADY_USED,#gmaNextGen
-            else
+            LoadAdError.ErrorCode.TIMEOUT, // #gmaNextGen
+            LoadAdError.ErrorCode.CANCELLED, // #gmaNextGen
+            LoadAdError.ErrorCode.NOT_FOUND, // #gmaNextGen
+            LoadAdError.ErrorCode.INVALID_AD_RESPONSE, // #gmaNextGen
+            LoadAdError.ErrorCode.AD_RESPONSE_ALREADY_USED, // #gmaNextGen
+                // else // #gmaLegacy
                 -> this.crashReporter.w(this, "Failed to receive rewarded ad! Error code: '${adError.code}' ($adError).")
         }
     }

--- a/app-android/src/main/java/org/mtransit/android/ad/rewarded/RewardedAdManager.kt
+++ b/app-android/src/main/java/org/mtransit/android/ad/rewarded/RewardedAdManager.kt
@@ -1,9 +1,9 @@
 package org.mtransit.android.ad.rewarded
 
-// import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAd #gmaNextGen
+// import com.google.android.gms.ads.rewarded.RewardedAd // #gmaLegacy
 import android.content.Context
 import androidx.annotation.StringRes
-import com.google.android.gms.ads.rewarded.RewardedAd
+import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAd // #gmaNextGen
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -82,8 +82,8 @@ class RewardedAdManager @Inject constructor(
         rewardedAdLoadingActivityHashCode = activityHashCode
         logAdsD(this@RewardedAdManager, "loadRewardedAdForActivity() > Loading rewarded ad for ${activity::class.java.simpleName}...")
         RewardedAd.load( // Must be called on the main UI thread
-            appContext,
-            appContext.getString(adUnitStringResId),
+            // appContext, // #gmaLegacy
+            // appContext.getString(adUnitStringResId), // #gmaLegacy
             AdManager.getAdRequest(
                 adUnitId = appContext.getString(adUnitStringResId)
             ),
@@ -161,8 +161,9 @@ class RewardedAdManager @Inject constructor(
 
         val theActivity = activity.requireActivity()
         logAdsD(this, "showRewardedAd() > Showing rewarded ad for ${theActivity::class.java.simpleName}...")
-        // this.rewardedAd?.adEventCallback = RewardedAdFullScreenContentCallback(this, this.crashReporter, activity) #gmaNextGen
-        this.rewardedAd?.fullScreenContentCallback = RewardedAdFullScreenContentCallback(this, this.crashReporter, activity)
+        // this.rewardedAd?.fullScreenContentCallback = // #gmaLegacy
+        this.rewardedAd?.adEventCallback = // #gmaNextGen
+            RewardedAdFullScreenContentCallback(this, this.crashReporter, activity)
         this.rewardedAd?.show(theActivity, RewardedAdOnUserEarnedRewardListener(this.globalAdManager, activity))
         //noinspection DiscouragedApi
         this.userManager.increaseRewardedShowCountsNow()

--- a/app-android/src/main/java/org/mtransit/android/ad/rewarded/RewardedAdOnUserEarnedRewardListener.kt
+++ b/app-android/src/main/java/org/mtransit/android/ad/rewarded/RewardedAdOnUserEarnedRewardListener.kt
@@ -1,9 +1,9 @@
 package org.mtransit.android.ad.rewarded
 
-import com.google.android.gms.ads.OnUserEarnedRewardListener
-import com.google.android.gms.ads.rewarded.RewardItem
-// import com.google.android.libraries.ads.mobile.sdk.rewarded.OnUserEarnedRewardListener #gmaNextGen
-// import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardItem #gmaNextGen
+// import com.google.android.gms.ads.OnUserEarnedRewardListener // #gmaLegacy
+// import com.google.android.gms.ads.rewarded.RewardItem // #gmaLegacy
+import com.google.android.libraries.ads.mobile.sdk.rewarded.OnUserEarnedRewardListener // #gmaNextGen
+import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardItem // #gmaNextGen
 import org.mtransit.android.ad.AdConstants.logAdsD
 import org.mtransit.android.ad.AdManager
 import org.mtransit.android.ad.GlobalAdManager

--- a/app-android/src/main/java/org/mtransit/android/ad/rewarded/RewardedUserManager.kt
+++ b/app-android/src/main/java/org/mtransit/android/ad/rewarded/RewardedUserManager.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.map
 import org.mtransit.android.R
 import org.mtransit.android.ad.AdConstants
-import org.mtransit.android.ad.AdConstants.logAdsD
 import org.mtransit.android.ad.AdManager
 import org.mtransit.android.commons.MTLog
 import org.mtransit.android.commons.TimeUtilsK


### PR DESCRIPTION
Keeps old code with `#gmaLegacy` and keep new code end-of-line comment `#gmaNextGen` for easy revert

-----

Needs:
- https://github.com/mtransitapps/commons/pull/843

Following:
- #121
- #200
- #215

Related to:
- #214