### PR TITLE
Crash > rewarded ads > `IllegalStateException` > "MobileAds.initialize must be called before using the Google Mobile Ads SDK"

### DIFF
--- a/app-android/detekt-baseline.xml
+++ b/app-android/detekt-baseline.xml
@@ -227,7 +227,6 @@
     <ID>NewLineAtEndOfFile:RDSRouteDirectionPagerAdapter.kt:org.mtransit.android.ui.rds.route.RDSRouteDirectionPagerAdapter.kt</ID>
     <ID>NewLineAtEndOfFile:RDSRouteViewModel.kt:org.mtransit.android.ui.rds.route.RDSRouteViewModel.kt</ID>
     <ID>NewLineAtEndOfFile:RecyclerViewExt.kt:org.mtransit.android.ui.view.common.RecyclerViewExt.kt</ID>
-    <ID>NewLineAtEndOfFile:RewardedAdManager.kt:org.mtransit.android.ad.rewarded.RewardedAdManager.kt</ID>
     <ID>NewLineAtEndOfFile:SVGDrawableTranscoder.kt:org.mtransit.android.ui.view.common.SVGDrawableTranscoder.kt</ID>
     <ID>NewLineAtEndOfFile:SVGModule.kt:org.mtransit.android.ui.view.common.SVGModule.kt</ID>
     <ID>NewLineAtEndOfFile:SavedStateHandleExt.kt:org.mtransit.android.ui.view.common.SavedStateHandleExt.kt</ID>

--- a/app-android/src/main/java/org/mtransit/android/ad/GlobalAdManager.kt
+++ b/app-android/src/main/java/org/mtransit/android/ad/GlobalAdManager.kt
@@ -80,6 +80,8 @@ class GlobalAdManager(
     private val initialized = AtomicBoolean(false)
     private val initializing = AtomicBoolean(false)
 
+    val isSDKInitialized: Boolean get() = this.initialized.get()
+
     @Volatile
     private var hasSubscription: Boolean? = null
 

--- a/app-android/src/main/java/org/mtransit/android/ad/rewarded/RewardedAdManager.kt
+++ b/app-android/src/main/java/org/mtransit/android/ad/rewarded/RewardedAdManager.kt
@@ -130,8 +130,8 @@ class RewardedAdManager @Inject constructor(
 
     suspend fun refreshRewardedAdStatus(activity: IActivity) = withContext(Dispatchers.IO) {
         if (!AdConstants.AD_ENABLED) return@withContext
-        if (!globalAdManager.adsAllowed()) {
-            logAdsD(this@RewardedAdManager, "refreshRewardedAdStatus() > SKIP (ads not allowed)")
+        if (!globalAdManager.isSDKInitialized) {
+            logAdsD(this@RewardedAdManager, "refreshRewardedAdStatus() > SKIP (SDK not initialized)")
             return@withContext
         }
         val canShowAds = globalAdManager.canShowAds()

--- a/app-android/src/main/java/org/mtransit/android/ad/rewarded/RewardedAdManager.kt
+++ b/app-android/src/main/java/org/mtransit/android/ad/rewarded/RewardedAdManager.kt
@@ -130,6 +130,10 @@ class RewardedAdManager @Inject constructor(
 
     suspend fun refreshRewardedAdStatus(activity: IActivity) = withContext(Dispatchers.IO) {
         if (!AdConstants.AD_ENABLED) return@withContext
+        if (!globalAdManager.adsAllowed()) {
+            logAdsD(this@RewardedAdManager, "refreshRewardedAdStatus() > SKIP (ads not allowed)")
+            return@withContext
+        }
         val canShowAds = globalAdManager.canShowAds()
         if (canShowAds != true) {
             logAdsD(this@RewardedAdManager, "refreshRewardedAdStatus() > SKIP (paying user or unknown)")


### PR DESCRIPTION
- #427