### PR TITLE
Turn on R8 obfuscation for Play Store (deadline: Feb 2027)

### DIFF
--- a/app-android/proguard-rules.pro
+++ b/app-android/proguard-rules.pro
@@ -6,7 +6,7 @@
 -keepattributes EnclosingMethod
 -keepattributes InnerClasses
 
-# Blocks all obfuscation (0%) > Play Store NOT happy:
+# '-dontobfuscate' blocks all obfuscation (0%) > Play Store NOT happy:
 # "Percentages under 25% in any category of your app may impact your visibility and publishing capabilities on Google Play.
 # To prevent this, optimize your app by the deadline." (Feb 2027)
 # # Do not obfuscate the class files since open source (DEBUG only)

--- a/app-android/proguard-rules.pro
+++ b/app-android/proguard-rules.pro
@@ -6,8 +6,11 @@
 -keepattributes EnclosingMethod
 -keepattributes InnerClasses
 
-# Do not obfuscate the class files since open source (DEBUG only)
--dontobfuscate
+# Blocks all obfuscation (0%) > Play Store NOT happy:
+# "Percentages under 25% in any category of your app may impact your visibility and publishing capabilities on Google Play.
+# To prevent this, optimize your app by the deadline." (Feb 2027)
+# # Do not obfuscate the class files since open source (DEBUG only)
+# -dontobfuscate
 
 # CRASHLYTICS - START
 # https://firebase.google.com/docs/crashlytics/android/get-deobfuscated-reports#config-r8-proguard-dexguard


### PR DESCRIPTION
> **App optimization is below our threshold**
> Improve your percentages in the following categories:
>
> - Obfuscation (0%)
> Percentages under 25% in any category of your app may impact your visibility and publishing capabilities on Google Play. To prevent this, optimize your app by the deadline. [Learn more](https://developer.android.com/topic/performance/app-optimization/enable-app-optimization).
>
> Fix by
> **Feb 2027**